### PR TITLE
fix: remove unnecessary approve step from dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,10 +16,9 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve and merge patch and minor updates
+      - name: Merge patch and minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Summary
- PR #206 added `gh pr review --approve` before `gh pr merge`, but `GITHUB_TOKEN` is not permitted to approve PRs → workflow fails at that step
- Approve step is unnecessary anyway: `main` has no branch protection, so `gh pr merge --squash` works without any prior approval
- Verified against PR #207, which failed at this exact step this morning

## Test plan
- [ ] This PR merges cleanly (it's not a dependabot PR, so the workflow won't run on it)
- [ ] After merge, comment \`@dependabot rebase\` on #207 to re-run the workflow against fixed main
- [ ] Confirm #207 auto-merges without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)