### PR TITLE
docs: record dependabot auto-merge fix in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,16 @@ toronto-public-library-search-browser-extension/
 - **ISBN Detection**: Auto-formats ISBN-10/ISBN-13 numbers
 - **Input Validation**: XSS protection and special character handling
 
-## Recent Changes (Nov 2024)
+## Recent Changes
+
+### Dependabot Auto-Merge Fixes (Apr 10, 2026)
+
+Auto-merge workflow had two latent bugs exposed when Dependabot created fresh PRs:
+
+- **#206**: Removed `--auto` flag from `gh pr merge`. The flag requires required status checks in branch protection, but this repo has none, causing "Pull request is in unstable status" errors. Also bumped `dependabot/fetch-metadata` v1→v2 (Node 20 deprecation).
+- **#216**: Removed the `gh pr review --approve` step that #206 introduced. `GITHUB_TOKEN` is not permitted to approve PRs by default, and the approval is unnecessary anyway — `main` has no branch protection, so `gh pr merge --squash` succeeds without any prior review.
+- Verified end-to-end: 8/9 concurrent Dependabot PRs (#207–#215) auto-merged by `app/github-actions` without human intervention; 1 auto-closed as superseded.
+- Gotcha: when many PRs target the same base concurrently, one will hit `"Base branch was modified"` — a single `@dependabot rebase` clears it.
 
 ### Dependabot Auto-Merge Workflow (Nov 24, 2025)
 


### PR DESCRIPTION
## Summary
Document the two latent bugs in the Dependabot auto-merge workflow (fixed in #206 and #216) and today's end-to-end verification, so the context survives into future sessions.

## Test plan
- [x] Content matches actual fix history
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)