### PR TITLE
chore: add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 
 # Claude Code local settings
 .claude/
+.venv/


### PR DESCRIPTION
## Summary
- Added `.venv/` to project `.gitignore` to match standardized venv naming convention

## Test plan
- [x] No functional changes, gitignore only

🤖 Generated with [Claude Code](https://claude.com/claude-code)