### PR TITLE
fix: update TPL search URL to new bibliocommons endpoint

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,7 +6,7 @@ chrome.runtime.onInstalled.addListener(() => {
   chrome.contextMenus.create({
     id: "searchTPL",
     title: "Search on TPL",
-    contexts: ["selection"]
+    contexts: ["selection"],
   });
 });
 
@@ -14,15 +14,15 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   if (info.menuItemId === "searchTPL" && info.selectionText) {
     const searchText = info.selectionText.trim();
-    
+
     if (searchText) {
       const processedText = processSearchText(searchText);
-      const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
-      
+      const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
+
       // Open TPL search in new tab
       chrome.tabs.create({
         url: tplUrl,
-        active: true
+        active: true,
       });
     }
   }
@@ -35,26 +35,26 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
  */
 function processSearchText(text) {
   // Remove excessive whitespace and normalize
-  let processed = text.replace(/\s+/g, ' ').trim();
-  
+  let processed = text.replace(/\s+/g, " ").trim();
+
   // Check if it looks like an ISBN
   if (isISBN(processed)) {
     // Clean ISBN: remove hyphens, spaces, and non-digits except X
-    processed = processed.replace(/[^0-9X]/gi, '');
+    processed = processed.replace(/[^0-9X]/gi, "");
     return processed;
   }
-  
+
   // For regular text searches, ensure it's not empty after cleaning
   if (!processed || processed.length === 0) {
-    console.warn('TPL Search: Empty search text after processing');
+    console.warn("TPL Search: Empty search text after processing");
     return text.trim(); // Fall back to original text
   }
-  
+
   // Limit length to reasonable search query size
   if (processed.length > 200) {
     processed = processed.substring(0, 200).trim();
   }
-  
+
   return processed;
 }
 
@@ -65,30 +65,32 @@ function processSearchText(text) {
  */
 function isISBN(text) {
   // Remove all non-alphanumeric characters for checking
-  const cleaned = text.replace(/[^0-9X]/gi, '');
-  
+  const cleaned = text.replace(/[^0-9X]/gi, "");
+
   // Check for 9, 10, or 13 digit patterns
-  return /^[0-9]{9}[0-9X]?$/i.test(cleaned) || // 9-10 digits (ISBN-10)
-         /^97[89][0-9]{10}$/i.test(cleaned);     // 13 digits starting with 978 or 979 (ISBN-13)
+  return (
+    /^[0-9]{9}[0-9X]?$/i.test(cleaned) || // 9-10 digits (ISBN-10)
+    /^97[89][0-9]{10}$/i.test(cleaned)
+  ); // 13 digits starting with 978 or 979 (ISBN-13)
 }
 
 // Listen for messages from content script (if needed for future features)
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.action === 'searchTPL') {
+  if (message.action === "searchTPL") {
     const processedText = processSearchText(message.text);
-    const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
-    
+    const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
+
     chrome.tabs.create({
       url: tplUrl,
-      active: true
+      active: true,
     });
-    
+
     sendResponse({ success: true });
   }
 });
 
 // Export functions for testing
-if (typeof global !== 'undefined') {
+if (typeof global !== "undefined") {
   global.processSearchText = processSearchText;
   global.isISBN = isISBN;
 }

--- a/popup.js
+++ b/popup.js
@@ -1,148 +1,161 @@
 // Popup script for TPL Search extension
 // Handles popup UI interactions and manual searches
 
-document.addEventListener('DOMContentLoaded', function() {
-  const searchInput = document.getElementById('searchInput');
-  const searchButton = document.getElementById('searchButton');
-  const selectedTextButton = document.getElementById('selectedTextButton');
-  const messageArea = document.getElementById('messageArea');
-  
+document.addEventListener("DOMContentLoaded", function () {
+  const searchInput = document.getElementById("searchInput");
+  const searchButton = document.getElementById("searchButton");
+  const selectedTextButton = document.getElementById("selectedTextButton");
+  const messageArea = document.getElementById("messageArea");
+
   // Check for selected text when popup opens
   checkSelectedText();
-  
+
   // Event listeners
-  searchButton.addEventListener('click', handleManualSearch);
-  selectedTextButton.addEventListener('click', handleSelectedTextSearch);
-  searchInput.addEventListener('keypress', function(e) {
-    if (e.key === 'Enter') {
+  searchButton.addEventListener("click", handleManualSearch);
+  selectedTextButton.addEventListener("click", handleSelectedTextSearch);
+  searchInput.addEventListener("keypress", function (e) {
+    if (e.key === "Enter") {
       handleManualSearch();
     }
   });
-  
-  searchInput.addEventListener('input', clearMessages);
-  
+
+  searchInput.addEventListener("input", clearMessages);
+
   /**
    * Check if there's selected text on the current page
    */
   function checkSelectedText() {
-    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       if (tabs[0]) {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'getSelectedText' }, function(response) {
-          if (chrome.runtime.lastError) {
-            // Content script might not be loaded yet, ignore error
-            return;
-          }
-          
-          if (response && response.success) {
-            selectedTextButton.disabled = false;
-            selectedTextButton.textContent = `Search: "${truncateText(response.text, 20)}"`;
-            
-            if (response.isbn && response.isbn.isISBN) {
-              showMessage(`Detected ${response.isbn.type}: ${response.isbn.cleaned}`, 'info');
+        chrome.tabs.sendMessage(
+          tabs[0].id,
+          { action: "getSelectedText" },
+          function (response) {
+            if (chrome.runtime.lastError) {
+              // Content script might not be loaded yet, ignore error
+              return;
             }
-            
-            if (response.warning) {
-              showMessage(response.warning, 'warning');
+
+            if (response && response.success) {
+              selectedTextButton.disabled = false;
+              selectedTextButton.textContent = `Search: "${truncateText(response.text, 20)}"`;
+
+              if (response.isbn && response.isbn.isISBN) {
+                showMessage(
+                  `Detected ${response.isbn.type}: ${response.isbn.cleaned}`,
+                  "info",
+                );
+              }
+
+              if (response.warning) {
+                showMessage(response.warning, "warning");
+              }
             }
-          }
-        });
+          },
+        );
       }
     });
   }
-  
+
   /**
    * Handle manual search from input field
    */
   function handleManualSearch() {
     const searchText = searchInput.value.trim();
-    
+
     if (!searchText) {
-      showMessage('Please enter search text', 'error');
+      showMessage("Please enter search text", "error");
       return;
     }
-    
+
     performSearch(searchText);
   }
-  
+
   /**
    * Handle search using selected text
    */
   function handleSelectedTextSearch() {
-    chrome.tabs.query({ active: true, currentWindow: true }, function(tabs) {
+    chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       if (tabs[0]) {
-        chrome.tabs.sendMessage(tabs[0].id, { action: 'getSelectedText' }, function(response) {
-          if (response && response.success) {
-            performSearch(response.text);
-          } else {
-            showMessage('No text selected or error getting selection', 'error');
-          }
-        });
+        chrome.tabs.sendMessage(
+          tabs[0].id,
+          { action: "getSelectedText" },
+          function (response) {
+            if (response && response.success) {
+              performSearch(response.text);
+            } else {
+              showMessage(
+                "No text selected or error getting selection",
+                "error",
+              );
+            }
+          },
+        );
       }
     });
   }
-  
+
   /**
    * Perform search with validation and error handling
    * @param {string} searchText - Text to search for
    */
   function performSearch(searchText) {
     if (!searchText || searchText.trim().length === 0) {
-      showMessage('Search text cannot be empty', 'error');
+      showMessage("Search text cannot be empty", "error");
       return;
     }
-    
+
     try {
       // Validate and process the search text
       const processed = processSearchText(searchText);
       const encodedText = encodeURIComponent(processed);
-      const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodedText}`;
-      
+      const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodedText}`;
+
       // Open TPL search in new tab
       chrome.tabs.create({
         url: tplUrl,
-        active: true
+        active: true,
       });
-      
+
       // Close popup after successful search
       window.close();
-      
     } catch (error) {
-      showMessage(`Search error: ${error.message}`, 'error');
+      showMessage(`Search error: ${error.message}`, "error");
     }
   }
-  
+
   /**
    * Process and validate search text
    * @param {string} text - The search text
    * @returns {string} - Processed text ready for search
    */
   function processSearchText(text) {
-    if (!text || typeof text !== 'string') {
-      throw new Error('Invalid search text');
+    if (!text || typeof text !== "string") {
+      throw new Error("Invalid search text");
     }
-    
+
     // Remove excessive whitespace and normalize
-    let processed = text.replace(/\s+/g, ' ').trim();
-    
+    let processed = text.replace(/\s+/g, " ").trim();
+
     if (processed.length === 0) {
-      throw new Error('Search text is empty after processing');
+      throw new Error("Search text is empty after processing");
     }
-    
+
     // Check if it looks like an ISBN
     if (isISBN(processed)) {
       // Clean ISBN: remove hyphens, spaces, and non-digits except X
-      processed = processed.replace(/[^0-9X]/gi, '');
+      processed = processed.replace(/[^0-9X]/gi, "");
       return processed;
     }
-    
+
     // Limit length to reasonable search query size
     if (processed.length > 200) {
       processed = processed.substring(0, 200).trim();
     }
-    
+
     return processed;
   }
-  
+
   /**
    * Check if text appears to be an ISBN
    * @param {string} text - The text to check
@@ -150,29 +163,31 @@ document.addEventListener('DOMContentLoaded', function() {
    */
   function isISBN(text) {
     // Remove all non-alphanumeric characters for checking
-    const cleaned = text.replace(/[^0-9X]/gi, '');
-    
+    const cleaned = text.replace(/[^0-9X]/gi, "");
+
     // Check for 9, 10, or 13 digit patterns
-    return /^[0-9]{9}[0-9X]?$/i.test(cleaned) || // 9-10 digits (ISBN-10)
-           /^97[89][0-9]{10}$/i.test(cleaned);     // 13 digits starting with 978 or 979 (ISBN-13)
+    return (
+      /^[0-9]{9}[0-9X]?$/i.test(cleaned) || // 9-10 digits (ISBN-10)
+      /^97[89][0-9]{10}$/i.test(cleaned)
+    ); // 13 digits starting with 978 or 979 (ISBN-13)
   }
-  
+
   /**
    * Show message to user
    * @param {string} message - Message to display
    * @param {string} type - Message type (info, error, warning)
    */
-  function showMessage(message, type = 'info') {
+  function showMessage(message, type = "info") {
     messageArea.innerHTML = `<div class="${type}">${escapeHtml(message)}</div>`;
   }
-  
+
   /**
    * Clear messages
    */
   function clearMessages() {
-    messageArea.innerHTML = '';
+    messageArea.innerHTML = "";
   }
-  
+
   /**
    * Truncate text for display
    * @param {string} text - Text to truncate
@@ -183,22 +198,22 @@ document.addEventListener('DOMContentLoaded', function() {
     if (text.length <= maxLength) {
       return text;
     }
-    return text.substring(0, maxLength - 3) + '...';
+    return text.substring(0, maxLength - 3) + "...";
   }
-  
+
   /**
    * Escape HTML to prevent XSS
    * @param {string} text - Text to escape
    * @returns {string} - Escaped text
    */
   function escapeHtml(text) {
-    const div = document.createElement('div');
+    const div = document.createElement("div");
     div.textContent = text;
     return div.innerHTML;
   }
 
   // Export functions for testing
-  if (typeof global !== 'undefined') {
+  if (typeof global !== "undefined") {
     global.processSearchText = processSearchText;
     global.truncateText = truncateText;
     global.escapeHtml = escapeHtml;

--- a/tests/fixtures/test-data.js
+++ b/tests/fixtures/test-data.js
@@ -5,220 +5,296 @@ export const testData = {
   // Valid ISBN test cases
   validISBNs: {
     isbn10: [
-      { input: '0123456789', cleaned: '0123456789', description: 'Basic ISBN-10' },
-      { input: '012345678X', cleaned: '012345678X', description: 'ISBN-10 with X check digit' },
-      { input: '0-123-45678-9', cleaned: '0123456789', description: 'ISBN-10 with hyphens' },
-      { input: '0 123 45678 9', cleaned: '0123456789', description: 'ISBN-10 with spaces' },
-      { input: 'ISBN: 0123456789', cleaned: '0123456789', description: 'ISBN-10 with prefix' }
+      {
+        input: "0123456789",
+        cleaned: "0123456789",
+        description: "Basic ISBN-10",
+      },
+      {
+        input: "012345678X",
+        cleaned: "012345678X",
+        description: "ISBN-10 with X check digit",
+      },
+      {
+        input: "0-123-45678-9",
+        cleaned: "0123456789",
+        description: "ISBN-10 with hyphens",
+      },
+      {
+        input: "0 123 45678 9",
+        cleaned: "0123456789",
+        description: "ISBN-10 with spaces",
+      },
+      {
+        input: "ISBN: 0123456789",
+        cleaned: "0123456789",
+        description: "ISBN-10 with prefix",
+      },
     ],
     isbn13: [
-      { input: '9780123456786', cleaned: '9780123456786', description: 'Basic ISBN-13' },
-      { input: '978-0-123-45678-6', cleaned: '9780123456786', description: 'ISBN-13 with hyphens' },
-      { input: '978 0 123 45678 6', cleaned: '9780123456786', description: 'ISBN-13 with spaces' },
-      { input: '9790987654321', cleaned: '9790987654321', description: 'ISBN-13 with 979 prefix' },
-      { input: 'ISBN-13: 978-0-123-45678-6', cleaned: '9780123456786', description: 'ISBN-13 with prefix' }
-    ]
+      {
+        input: "9780123456786",
+        cleaned: "9780123456786",
+        description: "Basic ISBN-13",
+      },
+      {
+        input: "978-0-123-45678-6",
+        cleaned: "9780123456786",
+        description: "ISBN-13 with hyphens",
+      },
+      {
+        input: "978 0 123 45678 6",
+        cleaned: "9780123456786",
+        description: "ISBN-13 with spaces",
+      },
+      {
+        input: "9790987654321",
+        cleaned: "9790987654321",
+        description: "ISBN-13 with 979 prefix",
+      },
+      {
+        input: "ISBN-13: 978-0-123-45678-6",
+        cleaned: "9780123456786",
+        description: "ISBN-13 with prefix",
+      },
+    ],
   },
 
   // Invalid ISBN test cases
   invalidISBNs: [
-    { input: '123456789', description: 'Too short (9 digits without check)' },
-    { input: '01234567890', description: 'Too long for ISBN-10' },
-    { input: '9770123456786', description: 'Invalid ISBN-13 prefix (977)' },
-    { input: 'abcdefghij', description: 'Non-numeric characters' },
-    { input: '978X123456786', description: 'X in wrong position for ISBN-13' },
-    { input: 'X123456789', description: 'X at start of ISBN-10' },
-    { input: '01234X6789', description: 'X in middle of ISBN-10' },
-    { input: '', description: 'Empty string' },
-    { input: '   ', description: 'Whitespace only' }
+    { input: "123456789", description: "Too short (9 digits without check)" },
+    { input: "01234567890", description: "Too long for ISBN-10" },
+    { input: "9770123456786", description: "Invalid ISBN-13 prefix (977)" },
+    { input: "abcdefghij", description: "Non-numeric characters" },
+    { input: "978X123456786", description: "X in wrong position for ISBN-13" },
+    { input: "X123456789", description: "X at start of ISBN-10" },
+    { input: "01234X6789", description: "X in middle of ISBN-10" },
+    { input: "", description: "Empty string" },
+    { input: "   ", description: "Whitespace only" },
   ],
 
   // Real-world book ISBN examples
   realWorldISBNs: [
-    { isbn: '978-0-13-235088-4', title: 'Clean Code: A Handbook of Agile Software Craftsmanship' },
-    { isbn: '0-201-61586-X', title: 'The Pragmatic Programmer' },
-    { isbn: '978-0-321-35668-0', title: 'Effective Java' },
-    { isbn: '0-596-52068-9', title: 'JavaScript: The Good Parts' },
-    { isbn: '978-1-449-31884-0', title: 'Learning React' },
-    { isbn: '978-0-134-68591-6', title: 'Refactoring: Improving the Design of Existing Code' },
-    { isbn: '0-7356-6745-7', title: 'Code Complete' },
-    { isbn: '978-0-596-51774-8', title: 'Head First Design Patterns' }
+    {
+      isbn: "978-0-13-235088-4",
+      title: "Clean Code: A Handbook of Agile Software Craftsmanship",
+    },
+    { isbn: "0-201-61586-X", title: "The Pragmatic Programmer" },
+    { isbn: "978-0-321-35668-0", title: "Effective Java" },
+    { isbn: "0-596-52068-9", title: "JavaScript: The Good Parts" },
+    { isbn: "978-1-449-31884-0", title: "Learning React" },
+    {
+      isbn: "978-0-134-68591-6",
+      title: "Refactoring: Improving the Design of Existing Code",
+    },
+    { isbn: "0-7356-6745-7", title: "Code Complete" },
+    { isbn: "978-0-596-51774-8", title: "Head First Design Patterns" },
   ],
 
   // Search term test cases
   searchTerms: {
     simple: [
-      { input: 'The Great Gatsby', expected: 'The Great Gatsby' },
-      { input: 'Margaret Atwood', expected: 'Margaret Atwood' },
-      { input: 'Clean Code', expected: 'Clean Code' }
+      { input: "The Great Gatsby", expected: "The Great Gatsby" },
+      { input: "Margaret Atwood", expected: "Margaret Atwood" },
+      { input: "Clean Code", expected: "Clean Code" },
     ],
     withSpecialChars: [
-      { input: 'Book title: "Test & More"', expected: 'Book title: "Test & More"' },
+      {
+        input: 'Book title: "Test & More"',
+        expected: 'Book title: "Test & More"',
+      },
       { input: "Author's Name", expected: "Author's Name" },
-      { input: 'Search with <html> tags', expected: 'Search with <html> tags' },
-      { input: 'Title with #hashtag', expected: 'Title with #hashtag' },
-      { input: 'Query with ? and =', expected: 'Query with ? and =' }
+      { input: "Search with <html> tags", expected: "Search with <html> tags" },
+      { input: "Title with #hashtag", expected: "Title with #hashtag" },
+      { input: "Query with ? and =", expected: "Query with ? and =" },
     ],
     withWhitespace: [
-      { input: '  trimmed text  ', expected: 'trimmed text' },
-      { input: '\t\ntest\r\n', expected: 'test' },
-      { input: 'multiple   spaces   between', expected: 'multiple spaces between' }
+      { input: "  trimmed text  ", expected: "trimmed text" },
+      { input: "\t\ntest\r\n", expected: "test" },
+      {
+        input: "multiple   spaces   between",
+        expected: "multiple spaces between",
+      },
     ],
     unicode: [
-      { input: 'Café Literature', expected: 'Café Literature' },
-      { input: 'Naïve Approach', expected: 'Naïve Approach' },
-      { input: 'Résumé Writing', expected: 'Résumé Writing' },
-      { input: '北京 Beijing', expected: '北京 Beijing' }
-    ]
+      { input: "Café Literature", expected: "Café Literature" },
+      { input: "Naïve Approach", expected: "Naïve Approach" },
+      { input: "Résumé Writing", expected: "Résumé Writing" },
+      { input: "北京 Beijing", expected: "北京 Beijing" },
+    ],
   },
 
   // URL encoding test cases
   urlEncoding: [
-    { input: 'The Great Gatsby', encoded: 'The%20Great%20Gatsby' },
-    { input: 'Author: Smith & Jones', encoded: 'Author%3A%20Smith%20%26%20Jones' },
-    { input: 'Book "Title"', encoded: 'Book%20%22Title%22' },
-    { input: 'Query with spaces', encoded: 'Query%20with%20spaces' },
-    { input: 'Special chars: !@#$%^&*()', encoded: 'Special%20chars%3A%20!%40%23%24%25%5E%26*()' }
+    { input: "The Great Gatsby", encoded: "The%20Great%20Gatsby" },
+    {
+      input: "Author: Smith & Jones",
+      encoded: "Author%3A%20Smith%20%26%20Jones",
+    },
+    { input: 'Book "Title"', encoded: "Book%20%22Title%22" },
+    { input: "Query with spaces", encoded: "Query%20with%20spaces" },
+    {
+      input: "Special chars: !@#$%^&*()",
+      encoded: "Special%20chars%3A%20!%40%23%24%25%5E%26*()",
+    },
   ],
 
   // Edge cases for testing
   edgeCases: {
     empty: [
-      { input: '', description: 'Empty string' },
-      { input: '   ', description: 'Whitespace only' },
-      { input: '\t\n\r', description: 'Tab and newline characters' }
+      { input: "", description: "Empty string" },
+      { input: "   ", description: "Whitespace only" },
+      { input: "\t\n\r", description: "Tab and newline characters" },
     ],
     long: [
-      { input: 'a'.repeat(100), description: '100 character string' },
-      { input: 'a'.repeat(200), description: '200 character string' },
-      { input: 'a'.repeat(500), description: '500 character string (max allowed)' },
-      { input: 'a'.repeat(1000), description: '1000 character string (should be truncated)' }
+      { input: "a".repeat(100), description: "100 character string" },
+      { input: "a".repeat(200), description: "200 character string" },
+      {
+        input: "a".repeat(500),
+        description: "500 character string (max allowed)",
+      },
+      {
+        input: "a".repeat(1000),
+        description: "1000 character string (should be truncated)",
+      },
     ],
     malicious: [
-      { input: '<script>alert("xss")</script>', description: 'XSS attempt' },
-      { input: 'javascript:alert("test")', description: 'JavaScript protocol' },
-      { input: '../../etc/passwd', description: 'Path traversal attempt' },
-      { input: 'DROP TABLE users;', description: 'SQL injection attempt' }
-    ]
+      { input: '<script>alert("xss")</script>', description: "XSS attempt" },
+      { input: 'javascript:alert("test")', description: "JavaScript protocol" },
+      { input: "../../etc/passwd", description: "Path traversal attempt" },
+      { input: "DROP TABLE users;", description: "SQL injection attempt" },
+    ],
   },
 
   // Context menu test scenarios
   contextMenuScenarios: [
     {
-      name: 'Basic book title search',
-      selectionText: 'The Catcher in the Rye',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=The%20Catcher%20in%20the%20Rye'
+      name: "Basic book title search",
+      selectionText: "The Catcher in the Rye",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=The%20Catcher%20in%20the%20Rye",
     },
     {
-      name: 'Author name search',
-      selectionText: 'J.D. Salinger',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=J.D.%20Salinger'
+      name: "Author name search",
+      selectionText: "J.D. Salinger",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=J.D.%20Salinger",
     },
     {
-      name: 'ISBN-10 search',
-      selectionText: '0-316-76948-7',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=0316769487'
+      name: "ISBN-10 search",
+      selectionText: "0-316-76948-7",
+      expectedURL: "https://tpl.bibliocommons.com/v2/search?query=0316769487",
     },
     {
-      name: 'ISBN-13 search',
-      selectionText: '978-0-316-76948-0',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780316769480'
+      name: "ISBN-13 search",
+      selectionText: "978-0-316-76948-0",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=9780316769480",
     },
     {
-      name: 'Complex search with special characters',
+      name: "Complex search with special characters",
       selectionText: 'Science Fiction: "Foundation" Series',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Science%20Fiction%3A%20%22Foundation%22%20Series'
-    }
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=Science%20Fiction%3A%20%22Foundation%22%20Series",
+    },
   ],
 
   // Error scenarios
   errorScenarios: [
     {
-      name: 'Empty selection',
-      selectionText: '',
-      shouldCreateTab: false
+      name: "Empty selection",
+      selectionText: "",
+      shouldCreateTab: false,
     },
     {
-      name: 'Whitespace only selection',
-      selectionText: '   ',
-      shouldCreateTab: false
+      name: "Whitespace only selection",
+      selectionText: "   ",
+      shouldCreateTab: false,
     },
     {
-      name: 'Wrong menu item ID',
-      menuItemId: 'wrongId',
-      selectionText: 'Valid text',
-      shouldCreateTab: false
-    }
+      name: "Wrong menu item ID",
+      menuItemId: "wrongId",
+      selectionText: "Valid text",
+      shouldCreateTab: false,
+    },
   ],
 
   // Popup test scenarios
   popupScenarios: [
     {
-      name: 'Manual search input',
-      inputText: 'Canadian Literature',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Canadian%20Literature'
+      name: "Manual search input",
+      inputText: "Canadian Literature",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=Canadian%20Literature",
     },
     {
-      name: 'Selected text search',
-      selectedText: 'Alice Munro',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Alice%20Munro'
+      name: "Selected text search",
+      selectedText: "Alice Munro",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=Alice%20Munro",
     },
     {
-      name: 'ISBN search from popup',
-      inputText: '978-0-7710-3386-2',
-      expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780771033862'
-    }
-  ]
+      name: "ISBN search from popup",
+      inputText: "978-0-7710-3386-2",
+      expectedURL:
+        "https://tpl.bibliocommons.com/v2/search?query=9780771033862",
+    },
+  ],
 };
 
 // Helper functions for tests
 export const testHelpers = {
   // Generate random ISBN-like strings for stress testing
-  generateRandomISBN: (type = 'isbn13') => {
-    if (type === 'isbn10') {
-      const digits = Array.from({ length: 9 }, () => Math.floor(Math.random() * 10)).join('');
-      const checkDigit = Math.random() > 0.5 ? Math.floor(Math.random() * 10) : 'X';
+  generateRandomISBN: (type = "isbn13") => {
+    if (type === "isbn10") {
+      const digits = Array.from({ length: 9 }, () =>
+        Math.floor(Math.random() * 10),
+      ).join("");
+      const checkDigit =
+        Math.random() > 0.5 ? Math.floor(Math.random() * 10) : "X";
       return digits + checkDigit;
     } else {
-      const prefix = Math.random() > 0.5 ? '978' : '979';
-      const digits = Array.from({ length: 10 }, () => Math.floor(Math.random() * 10)).join('');
+      const prefix = Math.random() > 0.5 ? "978" : "979";
+      const digits = Array.from({ length: 10 }, () =>
+        Math.floor(Math.random() * 10),
+      ).join("");
       return prefix + digits;
     }
   },
 
   // Generate text of specific length
-  generateTextOfLength: (length, char = 'a') => {
+  generateTextOfLength: (length, char = "a") => {
     return char.repeat(length);
   },
 
   // Create mock Chrome tab object
-  createMockTab: (id = 1, url = 'https://example.com', active = true) => ({
+  createMockTab: (id = 1, url = "https://example.com", active = true) => ({
     id,
     url,
     active,
-    title: 'Test Page',
-    windowId: 1
+    title: "Test Page",
+    windowId: 1,
   }),
 
   // Create mock selection info for context menu
-  createMockSelectionInfo: (text, menuItemId = 'searchTPL') => ({
+  createMockSelectionInfo: (text, menuItemId = "searchTPL") => ({
     menuItemId,
     selectionText: text,
     editable: false,
-    pageUrl: 'https://example.com'
+    pageUrl: "https://example.com",
   }),
 
   // Validate URL structure
   isValidTPLURL: (url) => {
-    const pattern = /^https:\/\/www\.torontopubliclibrary\.ca\/search\.jsp\?Ntt=.+$/;
+    const pattern = /^https:\/\/tpl\.bibliocommons\.com\/v2\/search\?query=.+$/;
     return pattern.test(url);
   },
 
   // Extract search term from TPL URL
   extractSearchTermFromURL: (url) => {
-    const match = url.match(/Ntt=(.+)$/);
+    const match = url.match(/[?&]query=(.+)$/);
     return match ? decodeURIComponent(match[1]) : null;
-  }
+  },
 };
 
 export default testData;

--- a/tests/integration/extension.test.js
+++ b/tests/integration/extension.test.js
@@ -1,343 +1,361 @@
 // Integration tests for the complete extension workflow
 // Tests end-to-end functionality and component interactions
 
-describe('Extension Integration Tests', () => {
+describe("Extension Integration Tests", () => {
   let mockTabs, mockContextMenus, mockRuntime;
-  
+
   beforeEach(() => {
     // Reset all chrome API mocks
     chrome.flush();
-    
+
     // Setup mock tabs
     mockTabs = [
-      { id: 1, url: 'https://example.com', active: true },
-      { id: 2, url: 'https://test.com', active: false }
+      { id: 1, url: "https://example.com", active: true },
+      { id: 2, url: "https://test.com", active: false },
     ];
-    
+
     chrome.tabs.query.yields(mockTabs);
-    chrome.tabs.create.yields({ id: 3, url: 'https://www.torontopubliclibrary.ca' });
-    chrome.tabs.sendMessage.yields({ success: true, text: 'test text' });
+    chrome.tabs.create.yields({ id: 3, url: "https://tpl.bibliocommons.com" });
+    chrome.tabs.sendMessage.yields({ success: true, text: "test text" });
   });
 
-  describe('Context Menu Workflow', () => {
-    test('should complete full context menu search workflow', () => {
+  describe("Context Menu Workflow", () => {
+    test("should complete full context menu search workflow", () => {
       // 1. Extension installs and creates context menu
       const installCallback = jest.fn();
       chrome.runtime.onInstalled.addListener(installCallback);
-      
+
       // Simulate installation
       chrome.runtime.onInstalled.trigger();
-      
+
       expect(chrome.contextMenus.create).toHaveBeenCalledWith({
         id: "searchTPL",
         title: "Search on TPL",
-        contexts: ["selection"]
+        contexts: ["selection"],
       });
-      
+
       // 2. User selects text and right-clicks
       const clickCallback = jest.fn();
       chrome.contextMenus.onClicked.addListener(clickCallback);
-      
+
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: "The Great Gatsby"
+        selectionText: "The Great Gatsby",
       };
       const mockTab = mockTabs[0];
-      
+
       // Simulate context menu click
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTab);
-      
+
       // 3. Verify new tab is created with correct TPL URL
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=The%20Great%20Gatsby',
-        active: true
+        url: "https://tpl.bibliocommons.com/v2/search?query=The%20Great%20Gatsby",
+        active: true,
       });
     });
 
-    test('should handle ISBN context menu search', () => {
+    test("should handle ISBN context menu search", () => {
       chrome.contextMenus.onClicked.addListener(jest.fn());
-      
+
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: "ISBN: 978-0-123-45678-6"
+        selectionText: "ISBN: 978-0-123-45678-6",
       };
-      
+
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
-      
+
       // ISBN should be cleaned before URL encoding
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780123456786',
-        active: true
+        url: "https://tpl.bibliocommons.com/v2/search?query=9780123456786",
+        active: true,
       });
     });
 
-    test('should handle special characters in context menu search', () => {
+    test("should handle special characters in context menu search", () => {
       chrome.contextMenus.onClicked.addListener(jest.fn());
-      
+
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: 'Book title: "Test & More"'
+        selectionText: 'Book title: "Test & More"',
       };
-      
+
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Book%20title%3A%20%22Test%20%26%20More%22',
-        active: true
+        url: "https://tpl.bibliocommons.com/v2/search?query=Book%20title%3A%20%22Test%20%26%20More%22",
+        active: true,
       });
     });
   });
 
-  describe('Popup Integration Workflow', () => {
-    test('should complete popup search workflow', async () => {
+  describe("Popup Integration Workflow", () => {
+    test("should complete popup search workflow", async () => {
       // 1. Popup opens and queries for selected text
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         expect(tabs).toEqual(mockTabs);
-        
+
         if (tabs[0]) {
           // 2. Send message to content script
-          chrome.tabs.sendMessage(tabs[0].id, { action: 'getSelectedText' }, (response) => {
-            expect(response.success).toBe(true);
-            expect(response.text).toBe('test text');
-          });
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            { action: "getSelectedText" },
+            (response) => {
+              expect(response.success).toBe(true);
+              expect(response.text).toBe("test text");
+            },
+          );
         }
       });
-      
+
       // 3. User performs search
-      const searchText = 'Manual search text';
-      const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(searchText)}`;
-      
+      const searchText = "Manual search text";
+      const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(searchText)}`;
+
       chrome.tabs.create({ url: tplUrl, active: true });
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Manual%20search%20text',
-        active: true
+        url: "https://tpl.bibliocommons.com/v2/search?query=Manual%20search%20text",
+        active: true,
       });
     });
 
-    test('should handle popup search with no selected text', () => {
-      chrome.tabs.sendMessage.yields({ success: false, error: 'No text selected' });
-      
+    test("should handle popup search with no selected text", () => {
+      chrome.tabs.sendMessage.yields({
+        success: false,
+        error: "No text selected",
+      });
+
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         if (tabs[0]) {
-          chrome.tabs.sendMessage(tabs[0].id, { action: 'getSelectedText' }, (response) => {
-            expect(response.success).toBe(false);
-            expect(response.error).toBe('No text selected');
-          });
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            { action: "getSelectedText" },
+            (response) => {
+              expect(response.success).toBe(false);
+              expect(response.error).toBe("No text selected");
+            },
+          );
         }
       });
     });
 
-    test('should handle runtime errors in popup workflow', () => {
-      chrome.runtime.lastError = { message: 'Extension context invalidated.' };
-      
+    test("should handle runtime errors in popup workflow", () => {
+      chrome.runtime.lastError = { message: "Extension context invalidated." };
+
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         if (tabs[0]) {
-          chrome.tabs.sendMessage(tabs[0].id, { action: 'getSelectedText' }, (response) => {
-            // Should handle error gracefully
-            expect(chrome.runtime.lastError).toBeDefined();
-          });
+          chrome.tabs.sendMessage(
+            tabs[0].id,
+            { action: "getSelectedText" },
+            (response) => {
+              // Should handle error gracefully
+              expect(chrome.runtime.lastError).toBeDefined();
+            },
+          );
         }
       });
     });
   });
 
-  describe('Content Script Communication', () => {
-    test('should handle content script to background message flow', () => {
+  describe("Content Script Communication", () => {
+    test("should handle content script to background message flow", () => {
       chrome.runtime.onMessage.addListener(jest.fn());
-      
+
       const mockMessage = {
-        action: 'searchTPL',
-        text: 'Content script search'
+        action: "searchTPL",
+        text: "Content script search",
       };
-      
+
       // Simulate message from content script
       chrome.runtime.onMessage.trigger(mockMessage, {}, jest.fn());
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledWith({
-        url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Content%20script%20search',
-        active: true
+        url: "https://tpl.bibliocommons.com/v2/search?query=Content%20script%20search",
+        active: true,
       });
     });
 
-    test('should validate messages between components', () => {
+    test("should validate messages between components", () => {
       const messageHandler = jest.fn((message, sender, sendResponse) => {
-        if (message.action === 'getSelectedText') {
+        if (message.action === "getSelectedText") {
           // Simulate content script response
           sendResponse({
             success: true,
-            text: 'Selected text',
-            isbn: { isISBN: false }
+            text: "Selected text",
+            isbn: { isISBN: false },
           });
         }
       });
-      
+
       chrome.runtime.onMessage.addListener(messageHandler);
-      
-      const mockMessage = { action: 'getSelectedText' };
+
+      const mockMessage = { action: "getSelectedText" };
       const mockSendResponse = jest.fn();
-      
+
       chrome.runtime.onMessage.trigger(mockMessage, {}, mockSendResponse);
-      
+
       expect(mockSendResponse).toHaveBeenCalledWith({
         success: true,
-        text: 'Selected text',
-        isbn: { isISBN: false }
+        text: "Selected text",
+        isbn: { isISBN: false },
       });
     });
   });
 
-  describe('Error Handling Integration', () => {
-    test('should handle tab creation failures', () => {
-      chrome.tabs.create.throws(new Error('Failed to create tab'));
-      
+  describe("Error Handling Integration", () => {
+    test("should handle tab creation failures", () => {
+      chrome.tabs.create.throws(new Error("Failed to create tab"));
+
       expect(() => {
         chrome.tabs.create({
-          url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=test',
-          active: true
+          url: "https://tpl.bibliocommons.com/v2/search?query=test",
+          active: true,
         });
-      }).toThrow('Failed to create tab');
+      }).toThrow("Failed to create tab");
     });
 
-    test('should handle content script communication failures', () => {
-      chrome.tabs.sendMessage.throws(new Error('Could not establish connection'));
-      
+    test("should handle content script communication failures", () => {
+      chrome.tabs.sendMessage.throws(
+        new Error("Could not establish connection"),
+      );
+
       expect(() => {
-        chrome.tabs.sendMessage(1, { action: 'getSelectedText' });
-      }).toThrow('Could not establish connection');
+        chrome.tabs.sendMessage(1, { action: "getSelectedText" });
+      }).toThrow("Could not establish connection");
     });
 
-    test('should handle context menu creation failures', () => {
-      chrome.contextMenus.create.throws(new Error('Failed to create context menu'));
-      
+    test("should handle context menu creation failures", () => {
+      chrome.contextMenus.create.throws(
+        new Error("Failed to create context menu"),
+      );
+
       expect(() => {
         chrome.contextMenus.create({
           id: "searchTPL",
           title: "Search on TPL",
-          contexts: ["selection"]
+          contexts: ["selection"],
         });
-      }).toThrow('Failed to create context menu');
+      }).toThrow("Failed to create context menu");
     });
   });
 
-  describe('End-to-End Scenarios', () => {
-    test('should handle complete user journey: select -> right-click -> search', () => {
+  describe("End-to-End Scenarios", () => {
+    test("should handle complete user journey: select -> right-click -> search", () => {
       const userJourney = {
-        selectedText: 'Clean Code by Robert Martin',
-        expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Clean%20Code%20by%20Robert%20Martin'
+        selectedText: "Clean Code by Robert Martin",
+        expectedURL:
+          "https://tpl.bibliocommons.com/v2/search?query=Clean%20Code%20by%20Robert%20Martin",
       };
-      
+
       // 1. Extension initialization
       chrome.runtime.onInstalled.trigger();
       expect(chrome.contextMenus.create).toHaveBeenCalled();
-      
+
       // 2. User selects text and right-clicks
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: userJourney.selectedText
+        selectionText: userJourney.selectedText,
       };
-      
+
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
-      
+
       // 3. Verify correct TPL search
       expect(chrome.tabs.create).toHaveBeenCalledWith({
         url: userJourney.expectedURL,
-        active: true
+        active: true,
       });
     });
 
-    test('should handle ISBN detection end-to-end', () => {
+    test("should handle ISBN detection end-to-end", () => {
       const isbnJourney = {
-        selectedText: 'Book with ISBN: 978-0-134-68591-6',
-        expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780134685916'
+        selectedText: "Book with ISBN: 978-0-134-68591-6",
+        expectedURL:
+          "https://tpl.bibliocommons.com/v2/search?query=9780134685916",
       };
-      
+
       chrome.runtime.onInstalled.trigger();
-      
+
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: isbnJourney.selectedText
+        selectionText: isbnJourney.selectedText,
       };
-      
+
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledWith({
         url: isbnJourney.expectedURL,
-        active: true
+        active: true,
       });
     });
 
-    test('should handle popup manual search end-to-end', () => {
+    test("should handle popup manual search end-to-end", () => {
       const manualSearch = {
-        searchText: 'Margaret Atwood novels',
-        expectedURL: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Margaret%20Atwood%20novels'
+        searchText: "Margaret Atwood novels",
+        expectedURL:
+          "https://tpl.bibliocommons.com/v2/search?query=Margaret%20Atwood%20novels",
       };
-      
+
       // Simulate popup workflow
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         // Popup gets active tab
         expect(tabs[0]).toBeDefined();
-        
+
         // User enters manual search
         chrome.tabs.create({
           url: manualSearch.expectedURL,
-          active: true
+          active: true,
         });
       });
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledWith({
         url: manualSearch.expectedURL,
-        active: true
+        active: true,
       });
     });
   });
 
-  describe('Performance and Edge Cases', () => {
-    test('should handle rapid successive searches', () => {
-      const searches = [
-        'First search',
-        'Second search',
-        'Third search'
-      ];
-      
-      searches.forEach(searchText => {
+  describe("Performance and Edge Cases", () => {
+    test("should handle rapid successive searches", () => {
+      const searches = ["First search", "Second search", "Third search"];
+
+      searches.forEach((searchText) => {
         const mockInfo = {
           menuItemId: "searchTPL",
-          selectionText: searchText
+          selectionText: searchText,
         };
-        
+
         chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
       });
-      
+
       expect(chrome.tabs.create).toHaveBeenCalledTimes(3);
     });
 
-    test('should handle empty and whitespace selections', () => {
-      const emptySelections = ['', '   ', '\t\n', null];
-      
-      emptySelections.forEach(selection => {
+    test("should handle empty and whitespace selections", () => {
+      const emptySelections = ["", "   ", "\t\n", null];
+
+      emptySelections.forEach((selection) => {
         const mockInfo = {
           menuItemId: "searchTPL",
-          selectionText: selection
+          selectionText: selection,
         };
-        
+
         chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
       });
-      
+
       // Should not create any tabs for empty selections
       expect(chrome.tabs.create).not.toHaveBeenCalled();
     });
 
-    test('should handle very long text selections', () => {
-      const longText = 'a'.repeat(1000);
-      
+    test("should handle very long text selections", () => {
+      const longText = "a".repeat(1000);
+
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: longText
+        selectionText: longText,
       };
-      
+
       chrome.contextMenus.onClicked.trigger(mockInfo, mockTabs[0]);
-      
+
       // Should truncate and still create tab
       expect(chrome.tabs.create).toHaveBeenCalled();
       const createCall = chrome.tabs.create.getCall(0);

--- a/tests/integration/simple-integration.test.js
+++ b/tests/integration/simple-integration.test.js
@@ -2,32 +2,32 @@
 // Tests core workflows without complex Chrome API mocking
 
 describe('Simple Integration Tests', () => {
-  
+
   describe('Search URL Generation', () => {
     test('should generate correct TPL URLs for different inputs', () => {
       const testScenarios = [
         {
           name: 'Basic book title',
           input: 'The Great Gatsby',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=The%20Great%20Gatsby'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=The%20Great%20Gatsby'
         },
         {
           name: 'Author name',
           input: 'Margaret Atwood',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Margaret%20Atwood'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=Margaret%20Atwood'
         },
         {
           name: 'ISBN-13',
           input: '978-0-123-45678-6',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780123456786'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=9780123456786'
         },
         {
           name: 'Special characters',
           input: 'Science Fiction: "Foundation" Series',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Science%20Fiction%3A%20%22Foundation%22%20Series'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=Science%20Fiction%3A%20%22Foundation%22%20Series'
         }
       ];
-      
+
       testScenarios.forEach(({ name, input, expected }) => {
         // Simulate the processing that would happen in the extension
         const processed = processSearchInput(input);
@@ -45,14 +45,14 @@ describe('Simple Integration Tests', () => {
         'Book title: "Test & More"',
         'a'.repeat(300) // Long text
       ];
-      
+
       inputs.forEach(input => {
         const processed = processSearchInput(input);
         expect(processed).toBeDefined();
         expect(typeof processed).toBe('string');
         expect(processed.length).toBeGreaterThan(0);
         expect(processed.length).toBeLessThanOrEqual(200);
-        
+
         // Should be valid for URL encoding
         const encoded = encodeURIComponent(processed);
         expect(encoded).toBeDefined();
@@ -63,7 +63,7 @@ describe('Simple Integration Tests', () => {
   describe('Error Handling', () => {
     test('should handle invalid inputs gracefully', () => {
       const invalidInputs = ['', '   ', null, undefined];
-      
+
       invalidInputs.forEach(input => {
         expect(() => {
           const processed = processSearchInput(input);
@@ -80,37 +80,37 @@ describe('Simple Integration Tests', () => {
     if (!text || typeof text !== 'string') {
       return '';
     }
-    
+
     let processed = text.replace(/\s+/g, ' ').trim();
-    
+
     if (processed.length === 0) {
       return '';
     }
-    
+
     // Check if it's an ISBN and clean it
     if (isISBN(processed)) {
       processed = processed.replace(/[^0-9X]/gi, '');
     }
-    
+
     // Truncate if too long
     if (processed.length > 200) {
       processed = processed.substring(0, 200).trim();
     }
-    
+
     return processed;
   }
-  
+
   function isISBN(text) {
     const cleaned = text.replace(/[^0-9X]/gi, '');
-    return /^[0-9]{9}[0-9X]$/i.test(cleaned) || 
+    return /^[0-9]{9}[0-9X]$/i.test(cleaned) ||
            /^97[89][0-9]{10}$/i.test(cleaned);
   }
-  
+
   function generateTPLUrl(searchTerm) {
     if (!searchTerm) {
       return null;
     }
     const encoded = encodeURIComponent(searchTerm);
-    return `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encoded}`;
+    return `https://tpl.bibliocommons.com/v2/search?query=${encoded}`;
   }
 });

--- a/tests/mocks/chrome-api.js
+++ b/tests/mocks/chrome-api.js
@@ -24,16 +24,16 @@ class MockContextMenus {
     if (!createProperties.id || !createProperties.title) {
       throw new Error('Missing required properties for context menu');
     }
-    
+
     this.menus.set(createProperties.id, {
       ...createProperties,
       enabled: true
     });
-    
+
     if (callback) {
       callback();
     }
-    
+
     return createProperties.id;
   }
 
@@ -41,10 +41,10 @@ class MockContextMenus {
     if (!this.menus.has(menuItemId)) {
       throw new Error(`Context menu item ${menuItemId} not found`);
     }
-    
+
     const existing = this.menus.get(menuItemId);
     this.menus.set(menuItemId, { ...existing, ...updateProperties });
-    
+
     if (callback) {
       callback();
     }
@@ -77,12 +77,12 @@ class MockContextMenus {
     if (!this.menus.has(menuItemId)) {
       return false;
     }
-    
+
     const clickInfo = {
       menuItemId,
       ...info
     };
-    
+
     this.onClicked.trigger(clickInfo, tab);
     return true;
   }
@@ -95,7 +95,7 @@ class MockTabs {
     this.onCreated = new MockEventHandler();
     this.onUpdated = new MockEventHandler();
     this.onRemoved = new MockEventHandler();
-    
+
     // Create a default active tab
     this.create({ url: 'https://example.com', active: true });
   }
@@ -114,42 +114,42 @@ class MockTabs {
       selected: createProperties.active !== false,
       status: 'loading'
     };
-    
+
     this.tabs.set(tab.id, tab);
     this.onCreated.trigger(tab);
-    
+
     // Simulate tab loading completion
     setTimeout(() => {
       tab.status = 'complete';
       this.onUpdated.trigger(tab.id, { status: 'complete' }, tab);
     }, 10);
-    
+
     if (callback) {
       callback(tab);
     }
-    
+
     return tab;
   }
 
   query(queryInfo, callback) {
     let results = Array.from(this.tabs.values());
-    
+
     if (queryInfo.active !== undefined) {
       results = results.filter(tab => tab.active === queryInfo.active);
     }
-    
+
     if (queryInfo.currentWindow !== undefined) {
       results = results.filter(tab => tab.windowId === 1); // Assume window 1 is current
     }
-    
+
     if (queryInfo.url !== undefined) {
       results = results.filter(tab => tab.url.includes(queryInfo.url));
     }
-    
+
     if (callback) {
       callback(results);
     }
-    
+
     return results;
   }
 
@@ -166,28 +166,28 @@ class MockTabs {
     if (!tab) {
       throw new Error(`Tab ${tabId} not found`);
     }
-    
+
     const updatedTab = { ...tab, ...updateProperties };
     this.tabs.set(tabId, updatedTab);
     this.onUpdated.trigger(tabId, updateProperties, updatedTab);
-    
+
     if (callback) {
       callback(updatedTab);
     }
-    
+
     return updatedTab;
   }
 
   remove(tabIds, callback) {
     const ids = Array.isArray(tabIds) ? tabIds : [tabIds];
-    
+
     ids.forEach(id => {
       if (this.tabs.has(id)) {
         this.tabs.delete(id);
         this.onRemoved.trigger(id, { windowId: 1, isWindowClosing: false });
       }
     });
-    
+
     if (callback) {
       callback();
     }
@@ -199,7 +199,7 @@ class MockTabs {
       callback = options;
       options = {};
     }
-    
+
     const tab = this.tabs.get(tabId);
     if (!tab) {
       if (callback) {
@@ -207,11 +207,11 @@ class MockTabs {
       }
       return;
     }
-    
+
     // Simulate message sending with various responses based on message type
     setTimeout(() => {
       let response;
-      
+
       switch (message.action) {
         case 'getSelectedText':
           response = {
@@ -226,7 +226,7 @@ class MockTabs {
         default:
           response = { success: false, error: 'Unknown action' };
       }
-      
+
       if (callback) {
         callback(response);
       }
@@ -265,7 +265,7 @@ class MockRuntime {
       callback = options;
       options = {};
     }
-    
+
     // Simulate async message handling
     setTimeout(() => {
       this.onMessage.trigger(message, { id: this.id }, callback || (() => {}));
@@ -312,13 +312,13 @@ class MockStorageArea {
   get(keys, callback) {
     const result = {};
     const keyArray = Array.isArray(keys) ? keys : [keys];
-    
+
     keyArray.forEach(key => {
       if (this.data.has(key)) {
         result[key] = this.data.get(key);
       }
     });
-    
+
     if (callback) {
       callback(result);
     }
@@ -327,15 +327,15 @@ class MockStorageArea {
 
   set(items, callback) {
     const changes = {};
-    
+
     Object.keys(items).forEach(key => {
       const oldValue = this.data.get(key);
       this.data.set(key, items[key]);
       changes[key] = { oldValue, newValue: items[key] };
     });
-    
+
     this.onChanged.trigger(changes, 'local');
-    
+
     if (callback) {
       callback();
     }
@@ -344,16 +344,16 @@ class MockStorageArea {
   remove(keys, callback) {
     const keyArray = Array.isArray(keys) ? keys : [keys];
     const changes = {};
-    
+
     keyArray.forEach(key => {
       if (this.data.has(key)) {
         changes[key] = { oldValue: this.data.get(key) };
         this.data.delete(key);
       }
     });
-    
+
     this.onChanged.trigger(changes, 'local');
-    
+
     if (callback) {
       callback();
     }
@@ -364,10 +364,10 @@ class MockStorageArea {
     this.data.forEach((value, key) => {
       changes[key] = { oldValue: value };
     });
-    
+
     this.data.clear();
     this.onChanged.trigger(changes, 'local');
-    
+
     if (callback) {
       callback();
     }
@@ -436,7 +436,7 @@ export const chromeTestUtils = {
   // Simulate tab creation with TPL search
   simulateTPLSearch(searchTerm) {
     const encodedTerm = encodeURIComponent(searchTerm);
-    const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodedTerm}`;
+    const url = `https://tpl.bibliocommons.com/v2/search?query=${encodedTerm}`;
     return mockChrome.tabs.create({ url, active: true });
   },
 

--- a/tests/unit/background-chrome.test.js
+++ b/tests/unit/background-chrome.test.js
@@ -2,350 +2,364 @@
 // Tests context menu, tabs, and runtime interactions with proper mocking
 
 // Use the hybrid setup
-require('../setup-hybrid');
+require("../setup-hybrid");
 
-describe('Background Script Chrome API Integration', () => {
+describe("Background Script Chrome API Integration", () => {
   let processSearchText, isISBN;
-  
+
   beforeEach(() => {
     // Setup Chrome API mocks
     setupChromeApiMocks();
-    
+
     // Define the core functions
-    processSearchText = function(text) {
-      let processed = text.replace(/\s+/g, ' ').trim();
-      
+    processSearchText = function (text) {
+      let processed = text.replace(/\s+/g, " ").trim();
+
       if (isISBN(processed)) {
-        processed = processed.replace(/[^0-9X]/gi, '');
+        processed = processed.replace(/[^0-9X]/gi, "");
         return processed;
       }
-      
+
       if (!processed || processed.length === 0) {
         return text.trim();
       }
-      
+
       if (processed.length > 200) {
         processed = processed.substring(0, 200).trim();
       }
-      
+
       return processed;
     };
-    
-    isISBN = function(text) {
-      const cleaned = text.replace(/[^0-9X]/gi, '');
-      return /^[0-9]{9}[0-9X]$/i.test(cleaned) || 
-             /^97[89][0-9]{10}$/i.test(cleaned);
+
+    isISBN = function (text) {
+      const cleaned = text.replace(/[^0-9X]/gi, "");
+      return (
+        /^[0-9]{9}[0-9X]$/i.test(cleaned) || /^97[89][0-9]{10}$/i.test(cleaned)
+      );
     };
   });
 
-  describe('Context Menu Creation', () => {
-    test('should create context menu on extension installation', () => {
+  describe("Context Menu Creation", () => {
+    test("should create context menu on extension installation", () => {
       // Simulate the installation callback
       const installCallback = () => {
         chrome.contextMenus.create({
           id: "searchTPL",
           title: "Search on TPL",
-          contexts: ["selection"]
+          contexts: ["selection"],
         });
       };
-      
+
       // Call the installation callback
       installCallback();
-      
+
       // Verify context menu was created
       expect(chrome.contextMenus.create.calledOnce).toBe(true);
-      expect(chrome.contextMenus.create.calledWith({
-        id: "searchTPL",
-        title: "Search on TPL",
-        contexts: ["selection"]
-      })).toBe(true);
+      expect(
+        chrome.contextMenus.create.calledWith({
+          id: "searchTPL",
+          title: "Search on TPL",
+          contexts: ["selection"],
+        }),
+      ).toBe(true);
     });
 
-    test('should handle context menu creation errors gracefully', () => {
+    test("should handle context menu creation errors gracefully", () => {
       // Make context menu creation throw an error
-      chrome.contextMenus.create.throws(new Error('Permission denied'));
-      
+      chrome.contextMenus.create.throws(new Error("Permission denied"));
+
       expect(() => {
         chrome.contextMenus.create({
           id: "searchTPL",
           title: "Search on TPL",
-          contexts: ["selection"]
+          contexts: ["selection"],
         });
-      }).toThrow('Permission denied');
+      }).toThrow("Permission denied");
     });
   });
 
-  describe('Context Menu Click Handling', () => {
-    test('should handle context menu clicks with valid selection', () => {
+  describe("Context Menu Click Handling", () => {
+    test("should handle context menu clicks with valid selection", () => {
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: "The Great Gatsby"
+        selectionText: "The Great Gatsby",
       };
       const mockTab = { id: 1 };
-      
+
       // Simulate the click handler
       const handleContextMenuClick = (info, tab) => {
         if (info.menuItemId === "searchTPL" && info.selectionText) {
           const searchText = info.selectionText.trim();
           if (searchText) {
             const processedText = processSearchText(searchText);
-            const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+            const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
             chrome.tabs.create({ url: tplUrl, active: true });
           }
         }
       };
-      
+
       // Execute the click handler
       handleContextMenuClick(mockInfo, mockTab);
-      
+
       // Verify tab creation
       expect(chrome.tabs.create.calledOnce).toBe(true);
       const createCall = chrome.tabs.create.getCall(0);
-      expect(createCall.args[0].url).toBe('https://www.torontopubliclibrary.ca/search.jsp?Ntt=The%20Great%20Gatsby');
+      expect(createCall.args[0].url).toBe(
+        "https://tpl.bibliocommons.com/v2/search?query=The%20Great%20Gatsby",
+      );
       expect(createCall.args[0].active).toBe(true);
     });
 
-    test('should handle ISBN context menu clicks with cleaning', () => {
+    test("should handle ISBN context menu clicks with cleaning", () => {
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: "ISBN: 978-0-123-45678-6"
+        selectionText: "ISBN: 978-0-123-45678-6",
       };
       const mockTab = { id: 1 };
-      
+
       const handleContextMenuClick = (info, tab) => {
         if (info.menuItemId === "searchTPL" && info.selectionText) {
           const searchText = info.selectionText.trim();
           if (searchText) {
             const processedText = processSearchText(searchText);
-            const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+            const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
             chrome.tabs.create({ url: tplUrl, active: true });
           }
         }
       };
-      
+
       handleContextMenuClick(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
       const createCall = chrome.tabs.create.getCall(0);
-      expect(createCall.args[0].url).toBe('https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780123456786');
+      expect(createCall.args[0].url).toBe(
+        "https://tpl.bibliocommons.com/v2/search?query=9780123456786",
+      );
     });
 
-    test('should ignore clicks without selection text', () => {
+    test("should ignore clicks without selection text", () => {
       const mockInfo = {
         menuItemId: "searchTPL",
-        selectionText: ""
+        selectionText: "",
       };
       const mockTab = { id: 1 };
-      
+
       const handleContextMenuClick = (info, tab) => {
         if (info.menuItemId === "searchTPL" && info.selectionText) {
           const searchText = info.selectionText.trim();
           if (searchText) {
             const processedText = processSearchText(searchText);
-            const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+            const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
             chrome.tabs.create({ url: tplUrl, active: true });
           }
         }
       };
-      
+
       handleContextMenuClick(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.called).toBe(false);
     });
 
-    test('should ignore clicks from other menu items', () => {
+    test("should ignore clicks from other menu items", () => {
       const mockInfo = {
         menuItemId: "otherMenuItem",
-        selectionText: "Some text"
+        selectionText: "Some text",
       };
       const mockTab = { id: 1 };
-      
+
       const handleContextMenuClick = (info, tab) => {
         if (info.menuItemId === "searchTPL" && info.selectionText) {
           const searchText = info.selectionText.trim();
           if (searchText) {
             const processedText = processSearchText(searchText);
-            const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+            const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
             chrome.tabs.create({ url: tplUrl, active: true });
           }
         }
       };
-      
+
       handleContextMenuClick(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.called).toBe(false);
     });
   });
 
-  describe('Tab Creation and URL Generation', () => {
-    test('should create tabs with properly encoded URLs', () => {
+  describe("Tab Creation and URL Generation", () => {
+    test("should create tabs with properly encoded URLs", () => {
       const testCases = [
         {
-          input: 'Book Title',
-          expectedUrl: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Book%20Title'
+          input: "Book Title",
+          expectedUrl:
+            "https://tpl.bibliocommons.com/v2/search?query=Book%20Title",
         },
         {
-          input: 'Author: Smith & Jones',
-          expectedUrl: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Author%3A%20Smith%20%26%20Jones'
+          input: "Author: Smith & Jones",
+          expectedUrl:
+            "https://tpl.bibliocommons.com/v2/search?query=Author%3A%20Smith%20%26%20Jones",
         },
         {
           input: 'Book "with quotes"',
-          expectedUrl: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Book%20%22with%20quotes%22'
-        }
+          expectedUrl:
+            "https://tpl.bibliocommons.com/v2/search?query=Book%20%22with%20quotes%22",
+        },
       ];
-      
+
       testCases.forEach(({ input, expectedUrl }, index) => {
         const processedText = processSearchText(input);
-        const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+        const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
         chrome.tabs.create({ url: tplUrl, active: true });
-        
+
         const createCall = chrome.tabs.create.getCall(index);
         expect(createCall.args[0].url).toBe(expectedUrl);
       });
     });
 
-    test('should handle tab creation failures', () => {
-      chrome.tabs.create.throws(new Error('Failed to create tab'));
-      
+    test("should handle tab creation failures", () => {
+      chrome.tabs.create.throws(new Error("Failed to create tab"));
+
       expect(() => {
         chrome.tabs.create({
-          url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=test',
-          active: true
+          url: "https://tpl.bibliocommons.com/v2/search?query=test",
+          active: true,
         });
-      }).toThrow('Failed to create tab');
+      }).toThrow("Failed to create tab");
     });
   });
 
-  describe('Runtime Message Handling', () => {
-    test('should handle searchTPL messages', () => {
+  describe("Runtime Message Handling", () => {
+    test("should handle searchTPL messages", () => {
       const mockMessage = {
-        action: 'searchTPL',
-        text: 'Search text'
+        action: "searchTPL",
+        text: "Search text",
       };
       const mockSender = {};
       const mockSendResponse = jest.fn();
-      
+
       // Simulate message handler
       const handleMessage = (message, sender, sendResponse) => {
-        if (message.action === 'searchTPL') {
+        if (message.action === "searchTPL") {
           const processedText = processSearchText(message.text);
-          const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+          const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
           chrome.tabs.create({ url: tplUrl, active: true });
           sendResponse({ success: true });
         }
       };
-      
+
       handleMessage(mockMessage, mockSender, mockSendResponse);
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
       expect(mockSendResponse).toHaveBeenCalledWith({ success: true });
     });
 
-    test('should handle unknown message actions', () => {
+    test("should handle unknown message actions", () => {
       const mockMessage = {
-        action: 'unknownAction',
-        text: 'Some text'
+        action: "unknownAction",
+        text: "Some text",
       };
       const mockSendResponse = jest.fn();
-      
+
       const handleMessage = (message, sender, sendResponse) => {
-        if (message.action === 'searchTPL') {
+        if (message.action === "searchTPL") {
           // Handle searchTPL
         } else {
-          sendResponse({ success: false, error: 'Unknown action' });
+          sendResponse({ success: false, error: "Unknown action" });
         }
       };
-      
+
       handleMessage(mockMessage, {}, mockSendResponse);
-      
-      expect(mockSendResponse).toHaveBeenCalledWith({ 
-        success: false, 
-        error: 'Unknown action' 
+
+      expect(mockSendResponse).toHaveBeenCalledWith({
+        success: false,
+        error: "Unknown action",
       });
     });
   });
 
-  describe('Search Processing Integration', () => {
-    test('should process various text types correctly for Chrome integration', () => {
+  describe("Search Processing Integration", () => {
+    test("should process various text types correctly for Chrome integration", () => {
       const searchTests = [
         {
-          input: '  whitespace around text  ',
-          expected: 'whitespace around text',
-          description: 'Whitespace trimming'
+          input: "  whitespace around text  ",
+          expected: "whitespace around text",
+          description: "Whitespace trimming",
         },
         {
-          input: '978-0-123-45678-6',
-          expected: '9780123456786',
-          description: 'ISBN cleaning'
+          input: "978-0-123-45678-6",
+          expected: "9780123456786",
+          description: "ISBN cleaning",
         },
         {
-          input: 'a'.repeat(250),
+          input: "a".repeat(250),
           expectedLength: 200,
-          description: 'Long text truncation'
-        }
+          description: "Long text truncation",
+        },
       ];
-      
-      searchTests.forEach(({ input, expected, expectedLength, description }) => {
-        const processed = processSearchText(input);
-        
-        if (expected) {
-          expect(processed).toBe(expected);
-        }
-        
-        if (expectedLength) {
-          expect(processed.length).toBe(expectedLength);
-        }
-        
-        // Verify it can be URL encoded without issues
-        expect(() => encodeURIComponent(processed)).not.toThrow();
-      });
+
+      searchTests.forEach(
+        ({ input, expected, expectedLength, description }) => {
+          const processed = processSearchText(input);
+
+          if (expected) {
+            expect(processed).toBe(expected);
+          }
+
+          if (expectedLength) {
+            expect(processed.length).toBe(expectedLength);
+          }
+
+          // Verify it can be URL encoded without issues
+          expect(() => encodeURIComponent(processed)).not.toThrow();
+        },
+      );
     });
 
-    test('should handle special characters safely', () => {
+    test("should handle special characters safely", () => {
       const specialChars = [
         '<script>alert("xss")</script>',
-        'SQL\'; DROP TABLE users; --',
-        '../../../etc/passwd',
-        'javascript:alert("test")'
+        "SQL'; DROP TABLE users; --",
+        "../../../etc/passwd",
+        'javascript:alert("test")',
       ];
-      
-      specialChars.forEach(maliciousInput => {
+
+      specialChars.forEach((maliciousInput) => {
         const processed = processSearchText(maliciousInput);
         const encoded = encodeURIComponent(processed);
-        const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encoded}`;
-        
+        const url = `https://tpl.bibliocommons.com/v2/search?query=${encoded}`;
+
         // Should not contain unencoded dangerous characters
-        expect(url).not.toContain('<script>');
-        expect(url).not.toContain('javascript:');
-        expect(url).not.toContain('DROP TABLE');
-        
+        expect(url).not.toContain("<script>");
+        expect(url).not.toContain("javascript:");
+        expect(url).not.toContain("DROP TABLE");
+
         // Should be properly URL encoded
-        expect(url).toMatch(/^https:\/\/www\.torontopubliclibrary\.ca\/search\.jsp\?Ntt=/);
+        expect(url).toMatch(
+          /^https:\/\/tpl\.bibliocommons\.com\/v2\/search\?query=/,
+        );
       });
     });
   });
 
-  describe('Performance with Chrome APIs', () => {
-    test('should handle rapid context menu clicks efficiently', () => {
+  describe("Performance with Chrome APIs", () => {
+    test("should handle rapid context menu clicks efficiently", () => {
       const startTime = Date.now();
-      
+
       // Simulate 100 rapid context menu clicks
       for (let i = 0; i < 100; i++) {
         const mockInfo = {
           menuItemId: "searchTPL",
-          selectionText: `Search term ${i}`
+          selectionText: `Search term ${i}`,
         };
-        
+
         // Simulate click handler
         const searchText = mockInfo.selectionText.trim();
         const processedText = processSearchText(searchText);
-        const tplUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processedText)}`;
+        const tplUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processedText)}`;
         chrome.tabs.create({ url: tplUrl, active: true });
       }
-      
+
       const endTime = Date.now();
       const duration = endTime - startTime;
-      
+
       // Should handle 100 operations quickly
       expect(duration).toBeLessThan(50);
       expect(chrome.tabs.create.callCount).toBe(100);

--- a/tests/unit/background-simple.test.js
+++ b/tests/unit/background-simple.test.js
@@ -3,31 +3,31 @@
 
 describe('Background Script Core Functions', () => {
   let processSearchText, isISBN;
-  
+
   beforeEach(() => {
     // Define core functions for testing
     processSearchText = function(text) {
       let processed = text.replace(/\s+/g, ' ').trim();
-      
+
       if (isISBN(processed)) {
         processed = processed.replace(/[^0-9X]/gi, '');
         return processed;
       }
-      
+
       if (!processed || processed.length === 0) {
         return text.trim();
       }
-      
+
       if (processed.length > 200) {
         processed = processed.substring(0, 200).trim();
       }
-      
+
       return processed;
     };
-    
+
     isISBN = function(text) {
       const cleaned = text.replace(/[^0-9X]/gi, '');
-      return /^[0-9]{9}[0-9X]$/i.test(cleaned) || 
+      return /^[0-9]{9}[0-9X]$/i.test(cleaned) ||
              /^97[89][0-9]{10}$/i.test(cleaned);
     };
   });
@@ -95,7 +95,7 @@ describe('Background Script Core Functions', () => {
         { input: 'Author: Smith & Jones', expected: 'Author%3A%20Smith%20%26%20Jones' },
         { input: 'Book "Title"', expected: 'Book%20%22Title%22' }
       ];
-      
+
       testCases.forEach(({ input, expected }) => {
         const processed = processSearchText(input);
         const encoded = encodeURIComponent(processed);
@@ -107,16 +107,16 @@ describe('Background Script Core Functions', () => {
       const searchTerm = 'Test Book';
       const processed = processSearchText(searchTerm);
       const encodedTerm = encodeURIComponent(processed);
-      const expectedUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodedTerm}`;
-      
-      expect(expectedUrl).toBe('https://www.torontopubliclibrary.ca/search.jsp?Ntt=Test%20Book');
+      const expectedUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodedTerm}`;
+
+      expect(expectedUrl).toBe('https://tpl.bibliocommons.com/v2/search?query=Test%20Book');
     });
 
     test('should handle special characters in URLs', () => {
       const specialText = 'Book title: "Test & More"';
       const processed = processSearchText(specialText);
       const encoded = encodeURIComponent(processed);
-      
+
       expect(encoded).toContain('%22'); // Quote
       expect(encoded).toContain('%26'); // Ampersand
       expect(encoded).toContain('%3A'); // Colon

--- a/tests/unit/background.test.js
+++ b/tests/unit/background.test.js
@@ -3,33 +3,33 @@
 
 describe('Background Script', () => {
   let backgroundScript;
-  
+
   beforeEach(() => {
     // Load the background script functions
     // Since we can't directly import, we'll test the functions by copying them
     global.processSearchText = function(text) {
       let processed = text.replace(/\s+/g, ' ').trim();
-      
+
       if (isISBN(processed)) {
         processed = processed.replace(/[^0-9X]/gi, '');
         return processed;
       }
-      
+
       if (!processed || processed.length === 0) {
         console.warn('TPL Search: Empty search text after processing');
         return text.trim();
       }
-      
+
       if (processed.length > 200) {
         processed = processed.substring(0, 200).trim();
       }
-      
+
       return processed;
     };
-    
+
     global.isISBN = function(text) {
       const cleaned = text.replace(/[^0-9X]/gi, '');
-      return /^[0-9]{9}[0-9X]$/i.test(cleaned) || 
+      return /^[0-9]{9}[0-9X]$/i.test(cleaned) ||
              /^97[89][0-9]{10}$/i.test(cleaned);
     };
   });
@@ -105,7 +105,7 @@ describe('Background Script', () => {
       // Simulate chrome.runtime.onInstalled
       const callback = chrome.runtime.onInstalled.addListener.getCall(0).args[0];
       callback();
-      
+
       expect(chrome.contextMenus.create.calledOnce).toBe(true);
       expect(chrome.contextMenus.create.calledWith({
         id: "searchTPL",
@@ -120,14 +120,14 @@ describe('Background Script', () => {
         selectionText: "The Great Gatsby"
       };
       const mockTab = { id: 1 };
-      
+
       // Simulate context menu click
       const callback = chrome.contextMenus.onClicked.addListener.getCall(0).args[0];
       callback(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
       const createCall = chrome.tabs.create.getCall(0);
-      expect(createCall.args[0].url).toContain('https://www.torontopubliclibrary.ca/search.jsp?Ntt=');
+      expect(createCall.args[0].url).toContain('https://tpl.bibliocommons.com/v2/search?query=');
       expect(createCall.args[0].active).toBe(true);
     });
 
@@ -137,10 +137,10 @@ describe('Background Script', () => {
         selectionText: ""
       };
       const mockTab = { id: 1 };
-      
+
       const callback = chrome.contextMenus.onClicked.addListener.getCall(0).args[0];
       callback(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.called).toBe(false);
     });
 
@@ -150,10 +150,10 @@ describe('Background Script', () => {
         selectionText: "Some text"
       };
       const mockTab = { id: 1 };
-      
+
       const callback = chrome.contextMenus.onClicked.addListener.getCall(0).args[0];
       callback(mockInfo, mockTab);
-      
+
       expect(chrome.tabs.create.called).toBe(false);
     });
   });
@@ -166,7 +166,7 @@ describe('Background Script', () => {
         { input: 'Book "Title"', expected: 'Book%20%22Title%22' },
         { input: 'Test with åéîøü', expected: 'Test%20with%20%C3%A5%C3%A9%C3%AE%C3%B8%C3%BC' }
       ];
-      
+
       testCases.forEach(({ input, expected }) => {
         const encoded = encodeURIComponent(processSearchText(input));
         expect(encoded).toBe(expected);
@@ -174,11 +174,11 @@ describe('Background Script', () => {
     });
 
     test('should create proper TPL URLs', () => {
-      const baseUrl = 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=';
+      const baseUrl = 'https://tpl.bibliocommons.com/v2/search?query=';
       const searchTerm = 'Test Book';
       const expectedUrl = baseUrl + encodeURIComponent(searchTerm);
-      
-      expect(expectedUrl).toBe('https://www.torontopubliclibrary.ca/search.jsp?Ntt=Test%20Book');
+
+      expect(expectedUrl).toBe('https://tpl.bibliocommons.com/v2/search?query=Test%20Book');
     });
   });
 });

--- a/tests/unit/popup-fixed.test.js
+++ b/tests/unit/popup-fixed.test.js
@@ -1,389 +1,415 @@
 // Fixed popup functionality tests
 // Tests popup UI interactions and Chrome API integration
 
-require('../setup-hybrid');
+require("../setup-hybrid");
 
-describe('Popup Functionality (Fixed)', () => {
+describe("Popup Functionality (Fixed)", () => {
   let mockDOMElements, processSearchText, validateSearchText;
-  
+
   beforeEach(() => {
     setupChromeApiMocks();
-    
+
     // Mock DOM elements that popup.js would interact with
     mockDOMElements = {
-      searchInput: { 
-        value: '', 
+      searchInput: {
+        value: "",
         addEventListener: jest.fn(),
-        focus: jest.fn()
+        focus: jest.fn(),
       },
-      searchButton: { 
+      searchButton: {
         addEventListener: jest.fn(),
         disabled: false,
-        click: jest.fn()
+        click: jest.fn(),
       },
-      selectedTextButton: { 
+      selectedTextButton: {
         addEventListener: jest.fn(),
         disabled: true,
-        textContent: 'Search Selected Text'
+        textContent: "Search Selected Text",
       },
-      messageArea: { 
-        innerHTML: ''
-      }
+      messageArea: {
+        innerHTML: "",
+      },
     };
-    
+
     // Mock document.getElementById
     document.getElementById = jest.fn((id) => mockDOMElements[id]);
-    
+
     // Define popup functions
-    processSearchText = function(text) {
+    processSearchText = function (text) {
       if (text === null || text === undefined) {
-        throw new Error('Invalid search text');
+        throw new Error("Invalid search text");
       }
-      
-      if (typeof text !== 'string') {
-        throw new Error('Invalid search text');
+
+      if (typeof text !== "string") {
+        throw new Error("Invalid search text");
       }
-      
-      let processed = text.replace(/\s+/g, ' ').trim();
-      
+
+      let processed = text.replace(/\s+/g, " ").trim();
+
       if (processed.length === 0) {
-        throw new Error('Search text is empty after processing');
+        throw new Error("Search text is empty after processing");
       }
-      
+
       if (isISBN(processed)) {
-        processed = processed.replace(/[^0-9X]/gi, '');
+        processed = processed.replace(/[^0-9X]/gi, "");
       }
-      
+
       if (processed.length > 200) {
         processed = processed.substring(0, 200).trim();
       }
-      
+
       return processed;
     };
-    
-    validateSearchText = function(text) {
-      if (!text || typeof text !== 'string') {
-        return { valid: false, error: 'No text selected' };
+
+    validateSearchText = function (text) {
+      if (!text || typeof text !== "string") {
+        return { valid: false, error: "No text selected" };
       }
-      
+
       const trimmed = text.trim();
-      
+
       if (trimmed.length === 0) {
-        return { valid: false, error: 'Selected text is empty' };
+        return { valid: false, error: "Selected text is empty" };
       }
-      
+
       if (trimmed.length > 500) {
-        return { 
-          valid: true, 
+        return {
+          valid: true,
           text: trimmed.substring(0, 500).trim(),
-          warning: 'Text was truncated to 500 characters'
+          warning: "Text was truncated to 500 characters",
         };
       }
-      
+
       return { valid: true, text: trimmed };
     };
-    
+
     function isISBN(text) {
-      const cleaned = text.replace(/[^0-9X]/gi, '');
-      return /^[0-9]{9}[0-9X]$/i.test(cleaned) || 
-             /^97[89][0-9]{10}$/i.test(cleaned);
+      const cleaned = text.replace(/[^0-9X]/gi, "");
+      return (
+        /^[0-9]{9}[0-9X]$/i.test(cleaned) || /^97[89][0-9]{10}$/i.test(cleaned)
+      );
     }
   });
 
-  describe('DOM Element Interaction', () => {
-    test('should initialize DOM elements correctly', () => {
+  describe("DOM Element Interaction", () => {
+    test("should initialize DOM elements correctly", () => {
       // Simulate popup initialization
-      const searchInput = document.getElementById('searchInput');
-      const searchButton = document.getElementById('searchButton');
-      const selectedTextButton = document.getElementById('selectedTextButton');
-      const messageArea = document.getElementById('messageArea');
-      
+      const searchInput = document.getElementById("searchInput");
+      const searchButton = document.getElementById("searchButton");
+      const selectedTextButton = document.getElementById("selectedTextButton");
+      const messageArea = document.getElementById("messageArea");
+
       expect(searchInput).toBeDefined();
       expect(searchButton).toBeDefined();
       expect(selectedTextButton).toBeDefined();
       expect(messageArea).toBeDefined();
-      
+
       expect(selectedTextButton.disabled).toBe(true);
     });
 
-    test('should setup event listeners', () => {
-      const searchInput = document.getElementById('searchInput');
-      const searchButton = document.getElementById('searchButton');
-      
+    test("should setup event listeners", () => {
+      const searchInput = document.getElementById("searchInput");
+      const searchButton = document.getElementById("searchButton");
+
       // Simulate adding event listeners
-      searchButton.addEventListener('click', jest.fn());
-      searchInput.addEventListener('keypress', jest.fn());
-      
-      expect(searchButton.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
-      expect(searchInput.addEventListener).toHaveBeenCalledWith('keypress', expect.any(Function));
+      searchButton.addEventListener("click", jest.fn());
+      searchInput.addEventListener("keypress", jest.fn());
+
+      expect(searchButton.addEventListener).toHaveBeenCalledWith(
+        "click",
+        expect.any(Function),
+      );
+      expect(searchInput.addEventListener).toHaveBeenCalledWith(
+        "keypress",
+        expect.any(Function),
+      );
     });
   });
 
-  describe('Search Input Processing', () => {
-    test('should process manual search input', () => {
+  describe("Search Input Processing", () => {
+    test("should process manual search input", () => {
       const testInputs = [
-        { input: 'The Great Gatsby', expected: 'The Great Gatsby' },
-        { input: '  whitespace test  ', expected: 'whitespace test' },
-        { input: '978-0-123-45678-6', expected: '9780123456786' }
+        { input: "The Great Gatsby", expected: "The Great Gatsby" },
+        { input: "  whitespace test  ", expected: "whitespace test" },
+        { input: "978-0-123-45678-6", expected: "9780123456786" },
       ];
-      
+
       testInputs.forEach(({ input, expected }) => {
         const result = processSearchText(input);
         expect(result).toBe(expected);
       });
     });
 
-    test('should validate search input', () => {
-      expect(validateSearchText('Valid text').valid).toBe(true);
-      expect(validateSearchText('').valid).toBe(false);
-      expect(validateSearchText('   ').valid).toBe(false);
+    test("should validate search input", () => {
+      expect(validateSearchText("Valid text").valid).toBe(true);
+      expect(validateSearchText("").valid).toBe(false);
+      expect(validateSearchText("   ").valid).toBe(false);
       expect(validateSearchText(null).valid).toBe(false);
     });
 
-    test('should handle input errors', () => {
-      expect(() => processSearchText('')).toThrow('Search text is empty after processing');
-      expect(() => processSearchText('   ')).toThrow('Search text is empty after processing');
-      expect(() => processSearchText(null)).toThrow('Invalid search text');
-      expect(() => processSearchText(undefined)).toThrow('Invalid search text');
+    test("should handle input errors", () => {
+      expect(() => processSearchText("")).toThrow(
+        "Search text is empty after processing",
+      );
+      expect(() => processSearchText("   ")).toThrow(
+        "Search text is empty after processing",
+      );
+      expect(() => processSearchText(null)).toThrow("Invalid search text");
+      expect(() => processSearchText(undefined)).toThrow("Invalid search text");
     });
   });
 
-  describe('Chrome Tab Integration', () => {
-    test('should query active tabs for selected text', () => {
-      const mockTabs = [{ id: 1, active: true, url: 'https://example.com' }];
+  describe("Chrome Tab Integration", () => {
+    test("should query active tabs for selected text", () => {
+      const mockTabs = [{ id: 1, active: true, url: "https://example.com" }];
       chrome.tabs.query.callsArgWith(1, mockTabs);
-      
+
       // Simulate popup querying for active tab
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         expect(tabs).toEqual(mockTabs);
         expect(tabs[0].active).toBe(true);
       });
-      
+
       expect(chrome.tabs.query.calledOnce).toBe(true);
-      expect(chrome.tabs.query.calledWith({ active: true, currentWindow: true })).toBe(true);
+      expect(
+        chrome.tabs.query.calledWith({ active: true, currentWindow: true }),
+      ).toBe(true);
     });
 
-    test('should send messages to content script', () => {
-      const mockResponse = { success: true, text: 'Selected text' };
+    test("should send messages to content script", () => {
+      const mockResponse = { success: true, text: "Selected text" };
       chrome.tabs.sendMessage.callsArgWith(2, mockResponse);
-      
-      chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
+
+      chrome.tabs.sendMessage(1, { action: "getSelectedText" }, (response) => {
         expect(response.success).toBe(true);
-        expect(response.text).toBe('Selected text');
+        expect(response.text).toBe("Selected text");
       });
-      
+
       expect(chrome.tabs.sendMessage.calledOnce).toBe(true);
     });
 
-    test('should create new tabs for searches', () => {
-      const searchText = 'Test search';
-      const expectedUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(searchText)}`;
-      
+    test("should create new tabs for searches", () => {
+      const searchText = "Test search";
+      const expectedUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(searchText)}`;
+
       chrome.tabs.create({ url: expectedUrl, active: true });
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
-      expect(chrome.tabs.create.calledWith({ url: expectedUrl, active: true })).toBe(true);
+      expect(
+        chrome.tabs.create.calledWith({ url: expectedUrl, active: true }),
+      ).toBe(true);
     });
   });
 
-  describe('Selected Text Detection', () => {
-    test('should enable selected text button when text is available', () => {
+  describe("Selected Text Detection", () => {
+    test("should enable selected text button when text is available", () => {
       const mockResponse = {
         success: true,
-        text: 'Selected text from page',
-        isbn: { isISBN: false }
+        text: "Selected text from page",
+        isbn: { isISBN: false },
       };
-      
+
       chrome.tabs.sendMessage.callsArgWith(2, mockResponse);
-      
+
       // Simulate checking for selected text
-      chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
+      chrome.tabs.sendMessage(1, { action: "getSelectedText" }, (response) => {
         if (response.success) {
-          const selectedTextButton = document.getElementById('selectedTextButton');
+          const selectedTextButton =
+            document.getElementById("selectedTextButton");
           selectedTextButton.disabled = false;
           selectedTextButton.textContent = `Search: "${response.text.substring(0, 20)}..."`;
         }
       });
-      
-      const selectedTextButton = document.getElementById('selectedTextButton');
+
+      const selectedTextButton = document.getElementById("selectedTextButton");
       expect(selectedTextButton.disabled).toBe(false);
-      expect(selectedTextButton.textContent).toContain('Search: "Selected text');
+      expect(selectedTextButton.textContent).toContain(
+        'Search: "Selected text',
+      );
     });
 
-    test('should handle ISBN detection in selected text', () => {
+    test("should handle ISBN detection in selected text", () => {
       const mockResponse = {
         success: true,
-        text: '978-0-123-45678-6',
-        isbn: { isISBN: true, type: 'ISBN-13', cleaned: '9780123456786' }
+        text: "978-0-123-45678-6",
+        isbn: { isISBN: true, type: "ISBN-13", cleaned: "9780123456786" },
       };
-      
+
       chrome.tabs.sendMessage.callsArgWith(2, mockResponse);
-      
-      chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
+
+      chrome.tabs.sendMessage(1, { action: "getSelectedText" }, (response) => {
         if (response.success && response.isbn.isISBN) {
-          expect(response.isbn.type).toBe('ISBN-13');
-          expect(response.isbn.cleaned).toBe('9780123456786');
+          expect(response.isbn.type).toBe("ISBN-13");
+          expect(response.isbn.cleaned).toBe("9780123456786");
         }
       });
     });
   });
 
-  describe('Search Execution', () => {
-    test('should perform manual search from input', () => {
-      const searchInput = document.getElementById('searchInput');
-      searchInput.value = 'Manual search term';
-      
+  describe("Search Execution", () => {
+    test("should perform manual search from input", () => {
+      const searchInput = document.getElementById("searchInput");
+      searchInput.value = "Manual search term";
+
       // Simulate manual search
       const searchText = searchInput.value.trim();
       if (searchText) {
         const processed = processSearchText(searchText);
-        const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processed)}`;
+        const url = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processed)}`;
         chrome.tabs.create({ url, active: true });
       }
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
       const createCall = chrome.tabs.create.getCall(0);
-      expect(createCall.args[0].url).toBe('https://www.torontopubliclibrary.ca/search.jsp?Ntt=Manual%20search%20term');
+      expect(createCall.args[0].url).toBe(
+        "https://tpl.bibliocommons.com/v2/search?query=Manual%20search%20term",
+      );
     });
 
-    test('should perform search with selected text', () => {
-      const mockResponse = { success: true, text: 'Selected text' };
+    test("should perform search with selected text", () => {
+      const mockResponse = { success: true, text: "Selected text" };
       chrome.tabs.sendMessage.callsArgWith(2, mockResponse);
-      
+
       // Simulate selected text search
-      chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
+      chrome.tabs.sendMessage(1, { action: "getSelectedText" }, (response) => {
         if (response.success) {
           const processed = processSearchText(response.text);
-          const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(processed)}`;
+          const url = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(processed)}`;
           chrome.tabs.create({ url, active: true });
         }
       });
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
     });
 
-    test('should close popup after successful search', () => {
-      const searchText = 'Test search';
-      const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(searchText)}`;
-      
+    test("should close popup after successful search", () => {
+      const searchText = "Test search";
+      const url = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(searchText)}`;
+
       chrome.tabs.create({ url, active: true });
       window.close();
-      
+
       expect(chrome.tabs.create.calledOnce).toBe(true);
       expect(window.close).toHaveBeenCalled();
     });
   });
 
-  describe('Error Handling', () => {
-    test('should handle empty search input', () => {
-      const searchInput = document.getElementById('searchInput');
-      searchInput.value = '';
-      
+  describe("Error Handling", () => {
+    test("should handle empty search input", () => {
+      const searchInput = document.getElementById("searchInput");
+      searchInput.value = "";
+
       const searchText = searchInput.value.trim();
-      let errorMessage = '';
-      
+      let errorMessage = "";
+
       if (!searchText) {
-        errorMessage = 'Please enter search text';
+        errorMessage = "Please enter search text";
       }
-      
-      expect(errorMessage).toBe('Please enter search text');
+
+      expect(errorMessage).toBe("Please enter search text");
       expect(chrome.tabs.create.called).toBe(false);
     });
 
-    test('should handle content script communication errors', () => {
-      chrome.runtime.lastError = { message: 'Extension context invalidated' };
+    test("should handle content script communication errors", () => {
+      chrome.runtime.lastError = { message: "Extension context invalidated" };
       chrome.tabs.sendMessage.callsArgWith(2, undefined);
-      
-      chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
+
+      chrome.tabs.sendMessage(1, { action: "getSelectedText" }, (response) => {
         if (chrome.runtime.lastError) {
-          expect(chrome.runtime.lastError.message).toBe('Extension context invalidated');
+          expect(chrome.runtime.lastError.message).toBe(
+            "Extension context invalidated",
+          );
         }
         expect(response).toBeUndefined();
       });
     });
 
-    test('should handle tab creation failures', () => {
-      chrome.tabs.create.throws(new Error('Cannot create tab'));
-      
+    test("should handle tab creation failures", () => {
+      chrome.tabs.create.throws(new Error("Cannot create tab"));
+
       expect(() => {
         chrome.tabs.create({
-          url: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=test',
-          active: true
+          url: "https://tpl.bibliocommons.com/v2/search?query=test",
+          active: true,
         });
-      }).toThrow('Cannot create tab');
+      }).toThrow("Cannot create tab");
     });
   });
 
-  describe('Message Display', () => {
-    test('should show info messages', () => {
-      const messageArea = document.getElementById('messageArea');
-      const message = 'Test info message';
-      
+  describe("Message Display", () => {
+    test("should show info messages", () => {
+      const messageArea = document.getElementById("messageArea");
+      const message = "Test info message";
+
       messageArea.innerHTML = `<div class="info">${message}</div>`;
-      
+
       expect(messageArea.innerHTML).toContain('class="info"');
       expect(messageArea.innerHTML).toContain(message);
     });
 
-    test('should show error messages', () => {
-      const messageArea = document.getElementById('messageArea');
-      const message = 'Test error message';
-      
+    test("should show error messages", () => {
+      const messageArea = document.getElementById("messageArea");
+      const message = "Test error message";
+
       messageArea.innerHTML = `<div class="error">${message}</div>`;
-      
+
       expect(messageArea.innerHTML).toContain('class="error"');
       expect(messageArea.innerHTML).toContain(message);
     });
 
-    test('should clear messages', () => {
-      const messageArea = document.getElementById('messageArea');
-      messageArea.innerHTML = '<div>Previous message</div>';
-      
-      messageArea.innerHTML = '';
-      
-      expect(messageArea.innerHTML).toBe('');
+    test("should clear messages", () => {
+      const messageArea = document.getElementById("messageArea");
+      messageArea.innerHTML = "<div>Previous message</div>";
+
+      messageArea.innerHTML = "";
+
+      expect(messageArea.innerHTML).toBe("");
     });
   });
 
-  describe('URL Generation and Security', () => {
-    test('should generate safe URLs for various inputs', () => {
+  describe("URL Generation and Security", () => {
+    test("should generate safe URLs for various inputs", () => {
       const testCases = [
-        { input: 'Normal book title', safe: true },
+        { input: "Normal book title", safe: true },
         { input: '<script>alert("xss")</script>', safe: true },
-        { input: 'SQL\'; DROP TABLE users; --', safe: true },
-        { input: 'javascript:alert("test")', safe: true }
+        { input: "SQL'; DROP TABLE users; --", safe: true },
+        { input: 'javascript:alert("test")', safe: true },
       ];
-      
+
       testCases.forEach(({ input, safe }) => {
         const processed = processSearchText(input);
         const encoded = encodeURIComponent(processed);
-        const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encoded}`;
-        
-        expect(url.startsWith('https://www.torontopubliclibrary.ca/search.jsp?Ntt=')).toBe(true);
-        
+        const url = `https://tpl.bibliocommons.com/v2/search?query=${encoded}`;
+
+        expect(
+          url.startsWith("https://tpl.bibliocommons.com/v2/search?query="),
+        ).toBe(true);
+
         if (safe) {
           // Should not contain unencoded dangerous content
-          expect(url).not.toContain('<script>');
-          expect(url).not.toContain('javascript:');
-          expect(url).not.toContain('DROP TABLE');
+          expect(url).not.toContain("<script>");
+          expect(url).not.toContain("javascript:");
+          expect(url).not.toContain("DROP TABLE");
         }
       });
     });
 
-    test('should handle Unicode characters properly', () => {
+    test("should handle Unicode characters properly", () => {
       const unicodeInputs = [
-        'Café Literature',
-        'Naïve Approach', 
-        'Résumé Writing',
-        '北京 Beijing'
+        "Café Literature",
+        "Naïve Approach",
+        "Résumé Writing",
+        "北京 Beijing",
       ];
-      
-      unicodeInputs.forEach(input => {
+
+      unicodeInputs.forEach((input) => {
         const processed = processSearchText(input);
         const encoded = encodeURIComponent(processed);
-        const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encoded}`;
-        
-        expect(url).toMatch(/^https:\/\/www\.torontopubliclibrary\.ca\/search\.jsp\?Ntt=/);
+        const url = `https://tpl.bibliocommons.com/v2/search?query=${encoded}`;
+
+        expect(url).toMatch(
+          /^https:\/\/tpl\.bibliocommons\.com\/v2\/search\?query=/,
+        );
         expect(() => new URL(url)).not.toThrow();
       });
     });

--- a/tests/unit/popup.test.js
+++ b/tests/unit/popup.test.js
@@ -4,27 +4,27 @@
 describe('Popup Script', () => {
   let mockDocument, mockWindow, mockChrome;
   let searchInput, searchButton, selectedTextButton, messageArea;
-  
+
   beforeEach(() => {
     // Mock DOM elements
-    searchInput = { 
-      value: '', 
+    searchInput = {
+      value: '',
       addEventListener: jest.fn(),
       focus: jest.fn()
     };
-    searchButton = { 
+    searchButton = {
       addEventListener: jest.fn(),
       disabled: false
     };
-    selectedTextButton = { 
+    selectedTextButton = {
       addEventListener: jest.fn(),
       disabled: true,
       textContent: 'Search Selected Text'
     };
-    messageArea = { 
+    messageArea = {
       innerHTML: ''
     };
-    
+
     // Mock document methods
     mockDocument = {
       addEventListener: jest.fn(),
@@ -39,51 +39,51 @@ describe('Popup Script', () => {
       }),
       createElement: jest.fn(() => ({ textContent: '', innerHTML: '' }))
     };
-    
+
     mockWindow = {
       close: jest.fn()
     };
-    
+
     global.document = mockDocument;
     global.window = mockWindow;
-    
+
     // Copy popup functions for testing
     global.processSearchText = function(text) {
       if (!text || typeof text !== 'string') {
         throw new Error('Invalid search text');
       }
-      
+
       let processed = text.replace(/\s+/g, ' ').trim();
-      
+
       if (processed.length === 0) {
         throw new Error('Search text is empty after processing');
       }
-      
+
       if (isISBN(processed)) {
         processed = processed.replace(/[^0-9X]/gi, '');
         return processed;
       }
-      
+
       if (processed.length > 200) {
         processed = processed.substring(0, 200).trim();
       }
-      
+
       return processed;
     };
-    
+
     global.isISBN = function(text) {
       const cleaned = text.replace(/[^0-9X]/gi, '');
-      return /^[0-9]{9}[0-9X]?$/i.test(cleaned) || 
+      return /^[0-9]{9}[0-9X]?$/i.test(cleaned) ||
              /^97[89][0-9]{10}$/i.test(cleaned);
     };
-    
+
     global.truncateText = function(text, maxLength) {
       if (text.length <= maxLength) {
         return text;
       }
       return text.substring(0, maxLength - 3) + '...';
     };
-    
+
     global.escapeHtml = function(text) {
       const div = document.createElement('div');
       div.textContent = text;
@@ -127,26 +127,26 @@ describe('Popup Script', () => {
       const testCases = [
         {
           input: 'The Great Gatsby',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=The%20Great%20Gatsby'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=The%20Great%20Gatsby'
         },
         {
           input: 'Author: Smith & Jones',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Author%3A%20Smith%20%26%20Jones'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=Author%3A%20Smith%20%26%20Jones'
         },
         {
           input: 'Book "Title" with quotes',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=Book%20%22Title%22%20with%20quotes'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=Book%20%22Title%22%20with%20quotes'
         },
         {
           input: '978-0-123-45678-6',
-          expected: 'https://www.torontopubliclibrary.ca/search.jsp?Ntt=9780123456786'
+          expected: 'https://tpl.bibliocommons.com/v2/search?query=9780123456786'
         }
       ];
-      
+
       testCases.forEach(({ input, expected }) => {
         const processed = processSearchText(input);
         const encoded = encodeURIComponent(processed);
-        const url = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encoded}`;
+        const url = `https://tpl.bibliocommons.com/v2/search?query=${encoded}`;
         expect(url).toBe(expected);
       });
     });
@@ -160,7 +160,7 @@ describe('Popup Script', () => {
         { char: '+', encoded: '%2B' },
         { char: ' ', encoded: '%20' }
       ];
-      
+
       specialChars.forEach(({ char, encoded }) => {
         const text = `test${char}text`;
         const processed = processSearchText(text);
@@ -190,13 +190,13 @@ describe('Popup Script', () => {
         textContent: '',
         innerHTML: ''
       };
-      
+
       document.createElement.mockReturnValue(mockDiv);
-      
+
       const maliciousInput = '<script>alert("xss")</script>';
       mockDiv.textContent = maliciousInput;
       mockDiv.innerHTML = '&lt;script&gt;alert("xss")&lt;/script&gt;';
-      
+
       const result = escapeHtml(maliciousInput);
       expect(result).toBe('&lt;script&gt;alert("xss")&lt;/script&gt;');
     });
@@ -205,13 +205,13 @@ describe('Popup Script', () => {
   describe('Chrome Extension Integration', () => {
     test('should query active tabs correctly', () => {
       chrome.tabs.query.yields([{ id: 1, url: 'https://example.com' }]);
-      
+
       // Simulate tab query
       chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
         expect(tabs).toHaveLength(1);
         expect(tabs[0].id).toBe(1);
       });
-      
+
       expect(chrome.tabs.query.calledWith({ active: true, currentWindow: true })).toBe(true);
     });
 
@@ -221,33 +221,33 @@ describe('Popup Script', () => {
         text: 'Selected text',
         isbn: { isISBN: false }
       };
-      
+
       chrome.tabs.sendMessage.yields(mockResponse);
-      
+
       chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
         expect(response.success).toBe(true);
         expect(response.text).toBe('Selected text');
       });
-      
+
       expect(chrome.tabs.sendMessage.calledWith(1, { action: 'getSelectedText' })).toBe(true);
     });
 
     test('should create new tabs with correct URL', () => {
       const searchText = 'Test Book';
-      const expectedUrl = `https://www.torontopubliclibrary.ca/search.jsp?Ntt=${encodeURIComponent(searchText)}`;
-      
+      const expectedUrl = `https://tpl.bibliocommons.com/v2/search?query=${encodeURIComponent(searchText)}`;
+
       chrome.tabs.create.yields({ id: 2, url: expectedUrl });
-      
+
       chrome.tabs.create({ url: expectedUrl, active: true }, (tab) => {
         expect(tab.url).toBe(expectedUrl);
       });
-      
+
       expect(chrome.tabs.create.calledWith({ url: expectedUrl, active: true })).toBe(true);
     });
 
     test('should handle chrome runtime errors gracefully', () => {
       chrome.runtime.lastError = { message: 'Extension context invalidated.' };
-      
+
       chrome.tabs.sendMessage(1, { action: 'getSelectedText' }, (response) => {
         // Should handle the error gracefully without throwing
         expect(chrome.runtime.lastError).toBeDefined();
@@ -258,7 +258,7 @@ describe('Popup Script', () => {
   describe('Error Handling', () => {
     test('should handle empty search input', () => {
       searchInput.value = '';
-      
+
       // Simulate manual search with empty input
       expect(() => {
         const searchText = searchInput.value.trim();
@@ -270,7 +270,7 @@ describe('Popup Script', () => {
 
     test('should handle search processing errors', () => {
       const invalidInputs = [null, undefined, '', '   '];
-      
+
       invalidInputs.forEach(input => {
         expect(() => processSearchText(input)).toThrow();
       });
@@ -279,7 +279,7 @@ describe('Popup Script', () => {
     test('should handle network/extension errors', () => {
       // Simulate network error
       chrome.tabs.create.throws(new Error('Network error'));
-      
+
       expect(() => {
         chrome.tabs.create({ url: 'https://example.com', active: true });
       }).toThrow('Network error');
@@ -290,10 +290,10 @@ describe('Popup Script', () => {
     test('should display info messages correctly', () => {
       const message = 'Test info message';
       const type = 'info';
-      
+
       // Simulate showMessage function
       messageArea.innerHTML = `<div class="${type}">${escapeHtml(message)}</div>`;
-      
+
       expect(messageArea.innerHTML).toContain('class="info"');
       expect(messageArea.innerHTML).toContain(message);
     });
@@ -301,19 +301,19 @@ describe('Popup Script', () => {
     test('should display error messages correctly', () => {
       const message = 'Test error message';
       const type = 'error';
-      
+
       messageArea.innerHTML = `<div class="${type}">${escapeHtml(message)}</div>`;
-      
+
       expect(messageArea.innerHTML).toContain('class="error"');
       expect(messageArea.innerHTML).toContain(message);
     });
 
     test('should clear messages', () => {
       messageArea.innerHTML = '<div class="info">Previous message</div>';
-      
+
       // Simulate clearMessages function
       messageArea.innerHTML = '';
-      
+
       expect(messageArea.innerHTML).toBe('');
     });
   });


### PR DESCRIPTION
## Summary

TPL migrated their catalog search to BiblioCommons. The extension's old URL (`https://www.torontopubliclibrary.ca/search.jsp?Ntt=<query>`) no longer routes to the live search engine.

This PR replaces it with the new endpoint: `https://tpl.bibliocommons.com/v2/search?query=<query>` — verified by the user with the example `https://tpl.bibliocommons.com/v2/search?query=murdle`.

## Changes

- `background.js` — both context-menu click and runtime message handlers now build the new URL
- `popup.js` — manual popup search now builds the new URL
- Tests + fixtures — every hardcoded `expectedURL`, `toMatch` regex, and helper updated to the new pattern; `extractSearchTermFromURL` helper now reads `query=` instead of `Ntt=`

The repo's pre-commit Prettier hook also normalized quote style and trailing commas in the touched files. The functional diff is the URL change; the rest is enforced formatting.

## Test plan

- [x] `npm test` (canonical CI suite: `background-simple` + `simple-integration`) — 15/15 pass
- [x] `npm run test:hybrid` — 52/65 pass; the 13 failures are pre-existing on `main` (sinon-chrome stub callback expectations unrelated to URL string), confirmed by running the same command on `main` and getting the identical failure count
- [ ] Manual sanity: load unpacked extension, right-click selected text → "Search on TPL" → verify the new URL opens
- [ ] Manual sanity: open popup, search "murdle" → verify the new URL opens

## Notes

- No `manifest.json` host permissions to update — the extension uses `activeTab` and only opens new tabs.
- Pre-existing test infra failures are tracked separately and not blocked by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)