### PR TITLE
fix(tests): repair sinon-chrome stub mocks for MV3 callback-less APIs

### DIFF
--- a/tests/setup-hybrid.js
+++ b/tests/setup-hybrid.js
@@ -1,48 +1,48 @@
 // Hybrid test setup - improved Chrome API mocking
-const chrome = require('sinon-chrome');
+const chrome = require("sinon-chrome");
 
 // Enhanced Chrome API setup
 global.chrome = chrome;
 
-// Mock window and document for content script tests
-global.window = {
-  getSelection: jest.fn(() => ({
-    toString: jest.fn(() => ''),
-    rangeCount: 0
-  })),
-  close: jest.fn()
-};
+// In a jsdom environment, `global.window` and `global.document` are
+// non-replaceable proxies into the jsdom Window — assigning a plain
+// object to `global.window` is silently ignored, so `window.close`
+// stays as jsdom's real close. When tests call `window.close()` on the
+// jsdom window, jsdom detaches the document, and every subsequent
+// test's `document.X = ...` blows up with "undefined". We instead
+// patch individual methods on the existing jsdom window/document.
+function installWindowMocks() {
+  window.close = jest.fn();
+  window.getSelection = jest.fn(() => ({
+    toString: jest.fn(() => ""),
+    rangeCount: 0,
+  }));
+}
 
-global.document = {
-  addEventListener: jest.fn(),
-  createElement: jest.fn(() => ({
-    textContent: '',
-    innerHTML: '',
-    style: {}
-  })),
-  getElementById: jest.fn(),
-  querySelector: jest.fn(),
-  querySelectorAll: jest.fn()
-};
+installWindowMocks();
 
 // Helper to setup sinon-chrome for specific tests
 global.setupChromeApiMocks = () => {
   // Reset all chrome API mocks
   chrome.flush();
-  
+
   // Setup default behaviors
-  chrome.tabs.create.callsArgWith(1, { id: 1, url: 'test' });
+  // Manifest V3 APIs return Promises; chrome.tabs.create and
+  // chrome.contextMenus.create are called without a callback, so use
+  // .resolves() instead of .callsArg*() (which throws when no callback
+  // arg is present).
+  chrome.tabs.create.resolves({ id: 1, url: "test" });
   chrome.tabs.query.callsArgWith(1, [{ id: 1, active: true }]);
   chrome.tabs.sendMessage.callsArgWith(2, { success: true });
-  chrome.contextMenus.create.callsArg(1);
+  chrome.contextMenus.create.resolves();
   chrome.runtime.sendMessage.callsArg(1);
-  
+
   return chrome;
 };
 
 // Helper to create realistic Chrome event triggers
 global.triggerChromeEvent = (eventName, ...args) => {
-  const event = chrome[eventName.split('.')[0]][eventName.split('.')[1]];
+  const event = chrome[eventName.split(".")[0]][eventName.split(".")[1]];
   if (event && event.trigger) {
     event.trigger(...args);
   }
@@ -52,7 +52,7 @@ global.triggerChromeEvent = (eventName, ...args) => {
 global.createMockSelection = (text) => {
   return {
     toString: () => text,
-    rangeCount: text ? 1 : 0
+    rangeCount: text ? 1 : 0,
   };
 };
 
@@ -61,9 +61,10 @@ beforeEach(() => {
   // Clear all mocks
   jest.clearAllMocks();
   chrome.flush();
-  
-  // Reset window.getSelection
-  global.window.getSelection.mockReturnValue(createMockSelection(''));
+
+  // Re-patch window methods so each test starts with a fresh mock
+  // (and so `window.close` never falls back to jsdom's real impl)
+  installWindowMocks();
 });
 
 // Cleanup after each test


### PR DESCRIPTION
## Summary

Fixes the 13 pre-existing test failures in \`tests/unit/background-chrome.test.js\` and \`tests/unit/popup-fixed.test.js\` that surfaced during PR #244. Two distinct bugs in \`tests/setup-hybrid.js\`:

1. **MV3 callback mismatch** — \`chrome.tabs.create\` and \`chrome.contextMenus.create\` were stubbed with \`.callsArg(N)\` / \`.callsArgWith(N, ...)\`, telling sinon to invoke arg-N as a callback. But the tests (matching Manifest V3 production code) call these APIs without a callback, so sinon throws \`"callsArg failed: 2 arguments required but only 1 present"\`. Switched to \`.resolves(...)\` so the mock matches MV3's Promise-returning shape.

2. **jsdom window can't be replaced wholesale** — \`global.window = { close: jest.fn() }\` is silently ignored under \`testEnvironment: 'jsdom'\` because jsdom's \`window\` is non-replaceable. The result: \`window.close\` stayed as jsdom's real \`close()\`. When the "should close popup after successful search" test called \`window.close()\`, jsdom actually closed the window — detaching \`document\` for every subsequent test, which then blew up in \`beforeEach\` with \`Cannot set properties of undefined (setting 'getElementById')\`. Fixed by patching individual methods (\`window.close\`, \`window.getSelection\`) directly on the existing jsdom window in a \`beforeEach\` hook.

## Test results

| Suite | main | this branch |
|---|---|---|
| \`npm test\` | 15/15 ✅ | 15/15 ✅ |
| \`npm run test:hybrid\` | 52/65 (13 fail) | **65/65 ✅** |
| \`npm run test:all\` | 127/178 (51 fail) | 140/178 (38 fail) |

The remaining 38 failures in \`test:all\` are pre-existing issues in other test files (\`popup.test.js\`, \`content.test.js\`, \`extension.test.js\`, \`source-coverage/*\`) that don't use \`setup-hybrid.js\` — out of scope for this PR. Net change: +13 passing, 0 regressions.

## Test plan

- [x] \`npm run test:hybrid\` is fully green (65/65)
- [x] \`npm test\` (canonical CI suite) still green (15/15)
- [x] No new failures introduced in \`test:all\` (count drops from 51 → 38)

## Notes

- This is the follow-up PR mentioned in #244. That PR updated the live search URL; this one cleans up the test infra exposed by running the full hybrid suite during that change.
- Several other test files have similar pre-existing infra issues (e.g., \`popup.test.js\` uses the older \`setup.js\` with the same \`global.window = {...}\` pattern). Could be a separate cleanup PR if the author wants to tackle the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)