### PR TITLE
fix: retry dependabot auto-merge on base-branch race

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,6 +19,13 @@ jobs:
       - name: Merge patch and minor updates
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
         run: |
+          # Concurrent Dependabot PRs race: whichever merges first invalidates the
+          # others' base SHA ("Base branch was modified"). Retry picks up the new SHA.
+          for attempt in 1 2 3; do
+            gh pr merge --squash "$PR_URL" && exit 0
+            echo "Merge attempt $attempt failed, retrying in 15s..."
+            sleep 15
+          done
           gh pr merge --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Problem

PR #359 did not auto-merge. The workflow ran, passed the metadata gate (semver-minor), and then failed:

```
GraphQL: Base branch was modified. Review and try the merge again. (mergePullRequest)
```

A sibling Dependabot PR merged into `main` in the seconds between the workflow reading the base SHA and calling merge. `gh pr merge` had no retry, and the workflow only fires `on: pull_request`, so nothing re-triggers it. The PR sat open with a red `auto-merge` check while everything else was green.

This is the same gotcha already documented in CLAUDE.md ("one will hit `Base branch was modified` — a single `@dependabot rebase` clears it"), now handled automatically instead of manually.

## Fix

Retry the merge up to 4 times with a 15s gap. A retry re-reads the base SHA, which is all this failure mode needs.

`--auto` is still not an option here: `main` has no branch protection / required checks, which is why #206 removed that flag in the first place.

## Testing

Workflow-only change; verified by the repo's YAML validation pre-commit hook. Real validation is the next batch of concurrent Dependabot PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qVL52BYmPZvvoMf93zcsD